### PR TITLE
qemu: fix $(ROOT) when current path contains 'build' not at the end

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -1,5 +1,5 @@
 BASH := $(shell which bash)
-ROOT ?= $(subst /build/,,$(shell pwd)/)
+ROOT ?= $(shell pwd)/..
 
 ################################################################################
 # Paths to git projects and various binaries


### PR DESCRIPTION
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>