### PR TITLE
Rework common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -28,74 +28,74 @@ CCACHE ?= $(shell which ccache) # Don't remove this comment (space is needed)
 # defines, macros, configuration etc
 ################################################################################
 define KERNEL_VERSION
-$(shell cd $(LINUX_PATH) && make --no-print-directory kernelversion)
+$(shell cd $(LINUX_PATH) && $(MAKE) --no-print-directory kernelversion)
 endef
 DEBUG ?= 0
 
 ################################################################################
 # OP-TEE
 ################################################################################
+OPTEE_OS_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_S_USER) \
+	CROSS_COMPILE_core=$(CROSS_COMPILE_S_KERNEL) \
+	CFG_TEE_CORE_LOG_LEVEL=3 \
+	DEBUG=$(DEBUG)
+
 optee-os-common:
-	make -C $(OPTEE_OS_PATH) \
-		CROSS_COMPILE=$(CROSS_COMPILE_S_USER) \
-		CROSS_COMPILE_core=$(CROSS_COMPILE_S_KERNEL) \
-		CFG_TEE_CORE_LOG_LEVEL=3 \
-		DEBUG=$(DEBUG) \
+	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS)
+
+OPTEE_OS_CLEAN_COMMON_FLAGS ?= $(OPTEE_OS_COMMON_FLAGS)
 
 optee-os-clean-common:
-	make -C $(OPTEE_OS_PATH) \
-		clean
+	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_CLEAN_COMMON_FLAGS) clean
+
+OPTEE_CLIENT_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)
 
 optee-client-common:
-	make -C $(OPTEE_CLIENT_PATH) \
-		CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)
+	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_COMMON_FLAGS)
+
+OPTEE_CLIENT_CLEAN_COMMON_FLAGS ?= $(OPTEE_CLIENT_COMMON_FLAGS)
 
 optee-client-clean-common:
-	make -C $(OPTEE_CLIENT_PATH) clean
+	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_CLEAN_COMMON_FLAGS) \
+		clean
+
+OPTEE_LINUXDRIVER_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
+	LOCALVERSION= M=$(OPTEE_LINUXDRIVER_PATH)
 
 optee-linuxdriver-common: linux
-	make -C $(LINUX_PATH) \
-		CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
-		LOCALVERSION= \
-		M=$(OPTEE_LINUXDRIVER_PATH) modules
+	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_COMMON_FLAGS) modules
+
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS ?= $(OPTEE_LINUXDRIVER_COMMON_FLAGS)
 
 optee-linuxdriver-clean-common:
-	make -C $(LINUX_PATH) \
-		M=$(OPTEE_LINUXDRIVER_PATH) clean
+	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS) clean
 
 ################################################################################
 # xtest / optee_test
 ################################################################################
+XTEST_COMMON_FLAGS ?= CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER)\
+	CROSS_COMPILE_TA=$(CROSS_COMPILE_S_USER) \
+	TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR) \
+	CFG_DEV_PATH=$(ROOT) \
+	O=$(OPTEE_TEST_OUT_PATH)
+
 xtest-common: optee-os optee-client
 	@if [ -d "$(OPTEE_TEST_PATH)" ]; then \
-		$(MAKE) -C $(OPTEE_TEST_PATH) \
-			CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER) \
-			CROSS_COMPILE_TA=$(CROSS_COMPILE_S_USER) \
-			TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR) \
-			CFG_DEV_PATH=$(ROOT) \
-			O=$(OPTEE_TEST_OUT_PATH); \
+		$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_COMMON_FLAGS); \
 	fi
+
+XTEST_CLEAN_COMMON_FLAGS ?= $(XTEST_COMMON_FLAGS)
 
 xtest-clean-common:
 	@if [ -d "$(OPTEE_TEST_PATH)" ]; then \
-		$(MAKE) -C $(OPTEE_TEST_PATH) \
-			CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER) \
-			CROSS_COMPILE_TA=$(CROSS_COMPILE_S_USER) \
-			TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR) \
-			CFG_DEV_PATH=$(ROOT) \
-			O=$(OPTEE_TEST_OUT_PATH) \
-				clean; \
+		$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_CLEAN_COMMON_FLAGS) clean; \
 	fi
+
+XTEST_PATCH_COMMON_FLAGS ?= $(XTEST_COMMON_FLAGS) \
+	CFG_OPTEE_TEST_PATH=$(OPTEE_TEST_PATH)
 
 xtest-patch-common: optee-os optee-client
 	@if [ -d "$(OPTEE_TEST_PATH)" ]; then \
-		$(MAKE) -C $(OPTEE_TEST_PATH) \
-			CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER) \
-			CROSS_COMPILE_TA=$(CROSS_COMPILE_S_USER) \
-			TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR) \
-			CFG_ARM32=y \
-			CFG_DEV_PATH=$(ROOT) \
-			CFG_OPTEE_TEST_PATH=$(OPTEE_TEST_PATH) \
-			O=$(OPTEE_TEST_OUT_PATH) \
-				patch; \
+		$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_PATCH_COMMON_FLAGS) \
+			patch; \
 	fi

--- a/fvp.mk
+++ b/fvp.mk
@@ -117,23 +117,20 @@ linux: linux-defconfig
 ################################################################################
 # OP-TEE
 ################################################################################
-optee-os:
-	$(MAKE) \
-		PLATFORM=vexpress \
-		PLATFORM_FLAVOR=fvp \
-		CFG_TEE_CORE_LOG_LEVEL=3 \
-			optee-os-common
+OPTEE_OS_COMMON_FLAGS += PLATFORM=vexpress-fvp
+optee-os: optee-os-common
 
-optee-os-clean:
-	$(MAKE) \
-		PLATFORM=vexpress \
-		PLATFORM_FLAVOR=fvp \
-			optee-os-clean-common
+OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=vexpress-fvp
+optee-os-clean: optee-os-clean-common
 
 optee-client: optee-client-common
+
 optee-client-clean: optee-client-clean-common
-optee-linuxdriver:
-	$(MAKE) ARCH=arm64 optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_COMMON_FLAGS += ARCH=arm64
+optee-linuxdriver: optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS += ARCH=arm64
 optee-linuxdriver-clean: optee-linuxdriver-clean-common
 
 generate-dtb:
@@ -146,8 +143,13 @@ generate-dtb:
 ################################################################################
 # xtest / optee_test
 ################################################################################
+XTEST_COMMON_FLAGS += CFG_ARM32=y
 xtest: xtest-common
+
+XTEST_CLEAN_COMMON_FLAGS += CFG_ARM32=y
 xtest-clean: xtest-clean-common
+
+XTEST_PATCH_COMMON_FLAGS += CFG_ARM32=y
 xtest-patch: xtest-patch-common
 
 ################################################################################

--- a/hikey.mk
+++ b/hikey.mk
@@ -221,23 +221,20 @@ linux-cleaner: linux-defconfig-clean
 ################################################################################
 # OP-TEE
 ################################################################################
-optee-os:
-	$(MAKE) \
-		CFG_ARM64_core=y \
-		PLATFORM=hikey \
-		CFG_TEE_CORE_LOG_LEVEL=3 \
-			optee-os-common
+OPTEE_OS_COMMON_FLAGS += PLATFORM=hikey CFG_ARM64_core=y
+optee-os: optee-os-common
 
-optee-os-clean:
-	$(MAKE) \
-                CFG_ARM64_core=y \
-                PLATFORM=hikey \
-			optee-os-clean-common
+OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=hikey CFG_ARM64_core=y
+optee-os-clean: optee-os-clean-common
 
 optee-client: optee-client-common
+
 optee-client-clean: optee-client-clean-common
-optee-linuxdriver:
-	$(MAKE) ARCH=arm64 optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_COMMON_FLAGS += ARCH=arm64
+optee-linuxdriver: optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS += ARCH=arm64
 optee-linuxdriver-clean: optee-linuxdriver-clean-common
 
 ################################################################################

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -54,7 +54,7 @@ $(LINUX_PATCH_PATH)/.patched:
 		$(LINUX_PATCH_PATH)/patch-all.sh
 	touch $@
 
-$(LINUX_PATH)/.config:
+$(LINUX_PATH)/.config: $(LINUX_PATCH_PATH)/.patched
 	# Temporary fix until we have the driver integrated in the kernel
 	sed -i '/config ARM64$$/a select DMA_SHARED_BUFFER' $(LINUX_PATH)/arch/arm64/Kconfig;
 	make -C $(LINUX_PATH) ARCH=arm64 defconfig

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -72,25 +72,20 @@ linux: linux-patched linux-defconfig
 ################################################################################
 # OP-TEE
 ################################################################################
-optee-os:
-	$(MAKE) \
-		CFG_ARM64_core=y \
-		PLATFORM=mediatek \
-		PLATFORM_FLAVOR=mt8173 \
-		CFG_TEE_CORE_LOG_LEVEL=4 \
-			optee-os-common
+OPTEE_OS_COMMON_FLAGS += PLATFORM=mediatek-mt8173 CFG_ARM64_core=y
+optee-os: optee-os-common
 
-optee-os-clean:
-	$(MAKE) \
-		PLATFORM=mediatek \
-		PLATFORM_FLAVOR=mt8173 \
-			optee-os-clean-common
+OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=mediatek-mt8173 CFG_ARM64_core=y
+optee-os-clean: optee-os-clean-common
 
 optee-client: optee-client-common
+
 optee-client-clean: optee-client-clean-common
 
-optee-linuxdriver:
-	$(MAKE) ARCH=arm64 optee-linuxdriver-common
+OPTEE_LINUXDRIVER_COMMON_FLAGS += ARCH=arm64
+optee-linuxdriver: optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS += ARCH=arm64
 optee-linuxdriver-clean: optee-linuxdriver-clean-common
 
 ################################################################################

--- a/qemu.mk
+++ b/qemu.mk
@@ -101,23 +101,20 @@ linux-clean:
 ################################################################################
 # OP-TEE
 ################################################################################
-optee-os:
-	$(MAKE) \
-		PLATFORM=vexpress \
-		PLATFORM_FLAVOR=qemu_virt \
-		CFG_TEE_CORE_LOG_LEVEL=3 \
-			optee-os-common
+OPTEE_OS_COMMON_FLAGS += PLATFORM=vexpress-qemu_virt
+optee-os: optee-os-common
 
-optee-os-clean:
-	$(MAKE) \
-		PLATFORM=vexpress \
-		PLATFORM_FLAVOR=qemu_virt \
-			optee-os-clean-common
+OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=vexpress-qemu_virt
+optee-os-clean: optee-os-clean-common
 
 optee-client: optee-client-common
+
 optee-client-clean: optee-client-clean-common
-optee-linuxdriver:
-	$(MAKE)	ARCH=arm optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_COMMON_FLAGS += ARCH=arm
+optee-linuxdriver: optee-linuxdriver-common
+
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS += ARCH=arm
 optee-linuxdriver-clean: optee-linuxdriver-clean-common
 
 ################################################################################
@@ -132,15 +129,14 @@ soc-term-clean:
 ################################################################################
 # xtest / optee_test
 ################################################################################
-xtest:
-	$(MAKE) xtest-common CFG_ARM32=y
+XTEST_COMMON_FLAGS += CFG_ARM32=y
+xtest: xtest-common
 
-xtest-clean:
-	$(MAKE) xtest-clean-common CFG_ARM32=y
+XTEST_CLEAN_COMMON_FLAGS += CFG_ARM32=y
+xtest-clean: xtest-clean-common
 
-xtest-patch:
-	$(MAKE) xtest-patch-common CFG_ARM32=y
-
+XTEST_PATCH_COMMON_FLAGS += CFG_ARM32=y
+xtest-patch: xtest-patch-common
 
 ################################################################################
 # Root FS
@@ -195,7 +191,8 @@ endef
 
 .PHONY: run
 # This target enforces updating root fs etc
-run: | bios-qemu run-only
+run: all
+	$(MAKE) run-only
 
 .PHONY: run-only
 run-only:


### PR DESCRIPTION
The code added by commits d6536da64deb ("Commonlize xtest compilation
among all platforms") and 070d95595e1d1 ("common build: optee
components") introduces race conditions that break parallel build (make
-jX). This is due to manually launching a make sub-process to run the
-common targets, and can be fixed by just declaring a dependency
instead. Specific flags are appended to common flags, rather than
passed as arguments to a new "make" sub-process.

So, basically:

 foo-common:
 	$(MAKE) -C foo_dir [A=a B=B]

 foo:
 	$(MAKE) foo-common [C=c]

is turned into:

 FOO_COMMON_FLAGS ?= A=a B=b
 foo-common:
 	$(MAKE) -C foo_dir $(FOO_COMMON_FLAGS)

 FOO_COMMON_FLAGS += C=c
 foo: foo-common

At the same time this allows foo: to override flags, for instance
set A=aa in the above example (prior to this, A=a would have had a
higher priority).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>