### PR TITLE
Hikey: Add flash and nvme targets

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -39,15 +39,16 @@ USBNETSH_PATH			?=$(ROOT)/out/usbnet.sh
 STRACE_PATH			?=$(ROOT)/strace
 BOOT_IMG			?=$(ROOT)/out/boot-fat.uefi.img
 LLOADER_PATH			?=$(ROOT)/l-loader
+NVME_IMG			?=$(ROOT)/out/nvme.img
 
 ################################################################################
 # Targets
 ################################################################################
-all: mcuimage arm-tf edk2 linux optee-os optee-client optee-linuxdriver xtest strace update_rootfs boot-img lloader
+all: mcuimage arm-tf edk2 linux optee-os optee-client optee-linuxdriver xtest strace update_rootfs boot-img lloader nvme
 
 clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean optee-client-clean optee-linuxdriver-clean xtest-clean strace-clean update_rootfs_clean boot-img-clean lloader-clean
 
-cleaner: clean mcuimage-cleaner busybox-cleaner linux-cleaner strace-cleaner
+cleaner: clean mcuimage-cleaner busybox-cleaner linux-cleaner strace-cleaner nvme-cleaner
 
 -include toolchain.mk
 
@@ -60,6 +61,7 @@ mcuimage:
 		curl https://builds.96boards.org/releases/hikey/linaro/binaries/latest/mcuimage.bin -o $(MCUIMAGE_BIN); \
 	fi
 
+.PHONY: mcuimage-cleaner
 mcuimage-cleaner:
 	rm -f $(MCUIMAGE_BIN)
 
@@ -80,6 +82,7 @@ arm-tf: mcuimage optee-os edk2
 	       SPD=opteed \
 	       all fip
 
+.PHONY: arm-tf-clean
 arm-tf-clean:
 	CFLAGS="-O0 -gdwarf-2" \
         CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" \
@@ -103,8 +106,10 @@ BUSYBOX_COMMON_CCDIR = $(AARCH64_PATH)
 
 busybox: busybox-common
 
+.PHONY: busybox-clean
 busybox-clean: busybox-clean-common
 
+.PHONY: busybox-cleaner
 busybox-cleaner: busybox-cleaner-common
 
 ################################################################################
@@ -120,6 +125,7 @@ endef
 
 edk2: edk2-common
 
+.PHONY: edk2-clean
 edk2-clean: edk2-clean-common
 
 ################################################################################
@@ -162,6 +168,7 @@ LINUX_COMMON_FLAGS += ARCH=arm64 Image modules dtbs
 
 linux: linux-common
 
+.PHONY: linux-defconfig-clean
 linux-defconfig-clean: linux-defconfig-clean-common
 	@if [ -f "$(LINUX_CONFIG_ADDLIST)" ]; then \
 		rm $(LINUX_CONFIG_ADDLIST); \
@@ -169,10 +176,12 @@ linux-defconfig-clean: linux-defconfig-clean-common
 
 LINUX_CLEAN_COMMON_FLAGS += ARCH=arm64
 
+.PHONY: linux-clean
 linux-clean: linux-clean-common
 
 LINUX_CLEANER_COMMON_FLAGS += ARCH=arm64
 
+.PHONY: linux-cleaner
 linux-cleaner: linux-cleaner-common
 
 ################################################################################
@@ -182,23 +191,30 @@ OPTEE_OS_COMMON_FLAGS += PLATFORM=hikey CFG_ARM64_core=y
 optee-os: optee-os-common
 
 OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=hikey CFG_ARM64_core=y
+.PHONY: optee-os-clean
 optee-os-clean: optee-os-clean-common
 
 optee-client: optee-client-common
 
+.PHONY: optee-client-clean
 optee-client-clean: optee-client-clean-common
 
 OPTEE_LINUXDRIVER_COMMON_FLAGS += ARCH=arm64
 optee-linuxdriver: optee-linuxdriver-common
 
 OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS += ARCH=arm64
+.PHONY: optee-linuxdriver-clean
 optee-linuxdriver-clean: optee-linuxdriver-clean-common
 
 ################################################################################
 # xtest / optee_test
 ################################################################################
 xtest: xtest-common
+
+.PHONY: xtest-clean
 xtest-clean: xtest-clean-common
+
+.PHONY: xtest-patch
 xtest-patch: xtest-patch-common
 
 ################################################################################
@@ -213,12 +229,14 @@ strace:
 			make -C $(STRACE_PATH); \
 	fi
 
+.PHONY: strace-clean
 strace-clean:
 	@if [ -f $(STRACE_PATH)/strace ]; then \
 		CC="$(CCACHE)$(AARCH64_CROSS_COMPILE)gcc" LD=$(AARCH64_CROSS_COMPILE)ld \
 			make -C $(STRACE_PATH) clean; \
 	fi
 
+.PHONY: strace-cleaner
 strace-cleaner:
 	rm -f $(STRACE_PATH)/Makefile $(STRACE_PATH)/configure
 
@@ -289,6 +307,7 @@ update_rootfs: busybox optee-client optee-linuxdriver filelist-tee linux-gen_ini
 	cd $(GEN_ROOTFS_PATH); \
 	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist.tmp | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz
 
+.PHONY: update_rootfs_clean
 update_rootfs_clean:
 	cd $(GEN_ROOTFS_PATH); \
 	rm -f $(GEN_ROOTFS_PATH)/filesystem.cpio.gz $(GEN_ROOTFS_PATH)/filelist.tmp $(GEN_ROOTFS_PATH)/filelist-tee.txt $(GEN_ROOTFS_PATH)/filelist-all.txt; \
@@ -310,6 +329,7 @@ boot-img: linux update_rootfs
 	sudo umount .tmpbootimg
 	sudo rm -rf .tmpbootimg
 
+.PHONY: boot-img-clean
 boot-img-clean:
 	rm -f $(BOOT_IMG)
 
@@ -322,6 +342,7 @@ lloader: arm-tf
 	fi
 	make -C $(LLOADER_PATH) BL1=$(ARM_TF_PATH)/build/hikey/$(ARM_TF_BUILD)/bl1.bin CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 
+.PHONY: lloader-clean
 lloader-clean:
 	if [ -h "$(LLOADER_PATH)/bl1.bin" ]; then \
 		unlink $(LLOADER_PATH)/bl1.bin; \
@@ -337,3 +358,25 @@ lloader-clean:
 		rm -f $(LLOADER_PATH)/temp.bin; \
 		rm -f $(LLOADER_PATH)/temp; \
 	fi
+
+################################################################################
+# nvme image
+################################################################################
+.PHONY: nvme
+nvme:
+	wget https://builds.96boards.org/releases/hikey/linaro/binaries/latest/nvme.img -O $(NVME_IMG)
+
+.PHONY: nvme-cleaner
+nvme-cleaner:
+	rm -f $(NVME_IMG)
+
+################################################################################
+# Flash
+################################################################################
+.PHONY: flash
+flash:
+	python $(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/l-loader.bin
+	fastboot flash ptable $(LLOADER_PATH)/ptable.img
+	fastboot flash fastboot $(ARM_TF_PATH)/build/hikey/release/fip.bin
+	fastboot flash nvme $(NVME_IMG)
+	fastboot flash boot $(BOOT_IMG)


### PR DESCRIPTION
Adds two new targets, one that downloads the necessary nvme.img file and
another target that flash the device. We have also added a couple of
.PHONY directives to a few targets.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>