### PR TITLE
qemu.mk: use xterm instead of gnome-terminal

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -193,7 +193,7 @@ endef
 
 define launch-terminal
 	@nc -z  127.0.0.1 $(1) || \
-	gnome-terminal -e "$(BASH) -c '$(SOC_TERM_PATH)/soc_term $(1); exec /bin/bash -i'" --title=$(2)
+	xterm -title $(2) -e $(BASH) -c "$(SOC_TERM_PATH)/soc_term $(1)" &
 endef
 
 .PHONY: run


### PR DESCRIPTION
- Make sure launch-terminal cannot block by adding a '&'
- Use xterm instead of gnome-terminal because it is more likely to be
installed by default.

Fixes https://github.com/OP-TEE/build/issues/18.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>