### PR TITLE
qemu.mk: Wait for terminals to be started before running QEMU

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -196,6 +196,10 @@ define launch-terminal
 	xterm -title $(2) -e $(BASH) -c "$(SOC_TERM_PATH)/soc_term $(1)" &
 endef
 
+define wait-for-ports
+       @while ! nc -z 127.0.0.1 $(1) || ! nc -z 127.0.0.1 $(2); do sleep 1; done
+endef
+
 .PHONY: run
 # This target enforces updating root fs etc
 run: all
@@ -206,7 +210,7 @@ run-only:
 	$(call run-help)
 	$(call launch-terminal,54320,"Normal World")
 	$(call launch-terminal,54321,"Secure World")
-	@sleep 1
+	$(call wait-for-ports,54320,54321)
 	$(QEMU_PATH)/arm-softmmu/qemu-system-arm \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \


### PR DESCRIPTION
At the moment we start several terminals, and then sleep for a second
before running a QEMU instance which will connect to processes run
in those terminals. This will fail if the terminals are displayed on
a slow remote X11 connection, because the terminals won't have
completed startup before the one second delay elapses.

Replace the delay with a loop that checks whether there's anything
listening on the relevant TCP ports yet.

Fixes #20 (GitHub issue)

Signed-off-by: Peter Maydell <peter.maydell@linaro.org>
Reviewed-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org>