### PR TITLE
Allow passing extra QEMU arguments to the run-only target via QEMU_EXTRA_ARGS

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -216,7 +216,7 @@ run-only:
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
 		-s -S -machine virt -cpu cortex-a15 \
 		-m 1057 \
-		-bios $(ROOT)/out/bios-qemu/bios.bin
+		-bios $(ROOT)/out/bios-qemu/bios.bin $(QEMU_EXTRA_ARGS)
 
 
 ifneq ($(filter check,$(MAKECMDGOALS)),)


### PR DESCRIPTION
It can sometimes be useful to pass extra arguments to the QEMU that is
launched via the 'run-only' target. Support this via an environment
variable QEMU_EXTRA_ARGS, which can be used like:
 make run-only QEMU_PATH=path/to/qemu/directory QEMU_EXTRA_ARGS='args here'

In particular, to use OP-TEE with a newer version of QEMU you need to pass "-machine secure=on". That will eventually need to go into qemu.mk when we update the OP-TEE version of QEMU, but until then we need a mechanism for specifying it if you are using a local QEMU.
