### PR TITLE
Fix the errors present in QEMU instructions-a64.h

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -57,7 +57,7 @@ bios-qemu-clean:
 	$(call bios-qemu-common) clean
 
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc"
+	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error"
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:


### PR DESCRIPTION
When compiling OP-TEE for QEMU with a recent version of GCC it
causes build errors `-Werror=unused-variable`.

By adding `--extra-cflags="-Wno-error"` to the makefile it safely
supresses the errors and allows OP-TEE to be compiled and built. This
error is also present in the `default_stable.xml` configuration with the
repo tool of the project.

See [OPTEE_OS issue 550](https://github.com/OP-TEE/optee_os/issues/550).

@vchong is also aware of issue. 