### PR TITLE
qemu: Add "-Wno-error" flag to qemu target

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -57,7 +57,7 @@ bios-qemu-clean:
 	$(call bios-qemu-common) clean
 
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc"
+	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error"
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:


### PR DESCRIPTION
GCC 5 and above fails to build OP-TEE project under QEMU.
Warnings are now treated as errors by default.

On line 60 --extra-cflags="-Wno-error" fixes the issue.
Please reference
[OP-TEE/optee_os#50](https://github.com/OP-TEE/optee_os/issues/550) for
specifics.

My machine is running gcc version 5.2.1 20151010 and I can confirm this
now works with change. It affects both default.xml and default_stable.xml repo
configurations for OP-TEE.