### PR TITLE
[RFC] Remove *_CLEAN_COMMON_FLAGS dependency on *_COMMON_FLAGS

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -73,15 +73,17 @@ linux-common: linux-defconfig
 linux-defconfig-clean-common:
 	@rm -f $(LINUX_PATH)/.config
 
-LINUX_CLEAN_COMMON_FLAGS ?= $(LINUX_COMMON_FLAGS)
-	
+# LINUX_CLEAN_COMMON_FLAGS can be defined in specific makefiles (hikey.mk,...)
+# if necessary
+
 linux-clean-common: linux-defconfig-clean
 	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEAN_COMMON_FLAGS) clean
 
-LINUX_CLEANER_COMMON_FLAGS ?= $(LINUX_COMMON_FLAGS)
+# LINUX_CLEANER_COMMON_FLAGS can be defined in specific makefiles (hikey.mk,...) 
+# if necessary
 
 linux-cleaner-common: linux-defconfig-clean
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEAN_COMMON_FLAGS) distclean
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEANER_COMMON_FLAGS) distclean
 
 ################################################################################
 # EDK2 / Tianocore
@@ -113,7 +115,8 @@ OPTEE_OS_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_S_USER) \
 optee-os-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS)
 
-OPTEE_OS_CLEAN_COMMON_FLAGS ?= $(OPTEE_OS_COMMON_FLAGS)
+# OPTEE_OS_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-os-clean-common: xtest-clean
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_CLEAN_COMMON_FLAGS) clean
@@ -123,7 +126,8 @@ OPTEE_CLIENT_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)
 optee-client-common:
 	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_COMMON_FLAGS)
 
-OPTEE_CLIENT_CLEAN_COMMON_FLAGS ?= $(OPTEE_CLIENT_COMMON_FLAGS)
+# OPTEE_CLIENT_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-client-clean-common:
 	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_CLEAN_COMMON_FLAGS) \
@@ -135,7 +139,8 @@ OPTEE_LINUXDRIVER_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
 optee-linuxdriver-common: linux
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_COMMON_FLAGS) modules
 
-OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS ?= $(OPTEE_LINUXDRIVER_COMMON_FLAGS)
+# OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-linuxdriver-clean-common:
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS) clean


### PR DESCRIPTION
Addresses https://github.com/OP-TEE/build/issues/28

The *_CLEAN_COMMON_FLAGS don't really need the variables/arguments/etc defined in *_COMMON_FLAGS for ```make clean```, so I just commented them out. The required variables are already defined in the platform .mk files themselves.

The only exception is maybe xtest. Do ```TA_DEV_KIT_DIR```, ```CFG_DEV_PATH``` and ```O``` have to be defined for cleaning?

Is this ok, or another method preferred?

Signed-off-by: Victor Chong <victor.chogn@linaro.org>