### PR TITLE
qemu: disable kernel CONFIG_JFFS2_FS

### DIFF
--- a/kconfig_no_jffs2.conf
+++ b/kconfig_no_jffs2.conf
@@ -1,0 +1,1 @@
+# CONFIG_JFFS2_FS is not set

--- a/qemu.mk
+++ b/qemu.mk
@@ -79,12 +79,13 @@ busybox-cleaner: busybox-cleaner-common
 ################################################################################
 # Linux kernel
 ################################################################################
-$(LINUX_PATH)/.config: kconfig_preempt.conf
+KCONFIGS := kconfig_preempt.conf kconfig_no_jffs2.conf
+$(LINUX_PATH)/.config: $(KCONFIGS)
 	# Temporary fix until we have the driver integrated in the kernel
 	sed -i '/config ARM$$/a select DMA_SHARED_BUFFER' $(LINUX_PATH)/arch/arm/Kconfig;
 	cd $(LINUX_PATH) && ARCH=arm scripts/kconfig/merge_config.sh \
 		arch/arm/configs/vexpress_defconfig \
-		$(CURDIR)/kconfig_preempt.conf
+		$(patsubst %,$(CURDIR)/%,$(KCONFIGS))
 
 linux-defconfig: $(LINUX_PATH)/.config
 


### PR DESCRIPTION
We have observed random failures of "make check" when run in the
Travis environment (OP-TEE regression testing). Every time it fails,
the log file has the following errors [1]:

  Starting QEMU...send: spawn id exp7 not open
      while executing
  "send -- "\r""
      (file "qemu-check.exp" line 54)
  == /home/travis/optee_repo/build/serial0.log:
  spawn ../qemu/arm-softmmu/qemu-system-arm -nographic [...]
  Using QEMU provided DTB at 0x40000000
  [...]
  squashfs: version 4.0 (2009/01/31) Phillip Lougher
  jffs2: version 2.2. (NAND) send: spawn id exp7 not open
      while executing
  "send -- "\r""
      (file "qemu-check.exp" line 54)
  == end of /home/travis/optee_repo/build/serial0.log

It seems that QEMU exits unexpectedly as the kernel is initializing
the JFFS2 filesystem driver. Since this is something we don't need, I
thought I'd just disable this driver and see if it makes things more
stable.
Well, indeed I could not reproduce the issue with this patch applied.

[1] https://travis-ci.org/OP-TEE/optee_os/builds/90051975#L4577

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>