### PR TITLE
common: Remove *_CLEAN_COMMON_FLAGS dependency on *_COMMON_FLAGS

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -73,15 +73,17 @@ linux-common: linux-defconfig
 linux-defconfig-clean-common:
 	@rm -f $(LINUX_PATH)/.config
 
-LINUX_CLEAN_COMMON_FLAGS ?= $(LINUX_COMMON_FLAGS)
-	
+# LINUX_CLEAN_COMMON_FLAGS can be defined in specific makefiles (hikey.mk,...)
+# if necessary
+
 linux-clean-common: linux-defconfig-clean
 	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEAN_COMMON_FLAGS) clean
 
-LINUX_CLEANER_COMMON_FLAGS ?= $(LINUX_COMMON_FLAGS)
+# LINUX_CLEANER_COMMON_FLAGS can be defined in specific makefiles (hikey.mk,...) 
+# if necessary
 
 linux-cleaner-common: linux-defconfig-clean
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEAN_COMMON_FLAGS) distclean
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEANER_COMMON_FLAGS) distclean
 
 ################################################################################
 # EDK2 / Tianocore
@@ -113,7 +115,8 @@ OPTEE_OS_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_S_USER) \
 optee-os-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS)
 
-OPTEE_OS_CLEAN_COMMON_FLAGS ?= $(OPTEE_OS_COMMON_FLAGS)
+# OPTEE_OS_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-os-clean-common: xtest-clean
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_CLEAN_COMMON_FLAGS) clean
@@ -123,7 +126,8 @@ OPTEE_CLIENT_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)
 optee-client-common:
 	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_COMMON_FLAGS)
 
-OPTEE_CLIENT_CLEAN_COMMON_FLAGS ?= $(OPTEE_CLIENT_COMMON_FLAGS)
+# OPTEE_CLIENT_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-client-clean-common:
 	$(MAKE) -C $(OPTEE_CLIENT_PATH) $(OPTEE_CLIENT_CLEAN_COMMON_FLAGS) \
@@ -135,7 +139,8 @@ OPTEE_LINUXDRIVER_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
 optee-linuxdriver-common: linux
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_COMMON_FLAGS) modules
 
-OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS ?= $(OPTEE_LINUXDRIVER_COMMON_FLAGS)
+# OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS can be defined in specific makefiles
+# (hikey.mk,...) if necessary
 
 optee-linuxdriver-clean-common:
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS) clean
@@ -152,7 +157,7 @@ XTEST_COMMON_FLAGS ?= CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER)\
 xtest-common: optee-os optee-client
 	$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_COMMON_FLAGS)
 
-XTEST_CLEAN_COMMON_FLAGS ?= $(XTEST_COMMON_FLAGS)
+XTEST_CLEAN_COMMON_FLAGS ?= TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR)
 
 xtest-clean-common:
 	$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_CLEAN_COMMON_FLAGS) clean


### PR DESCRIPTION
Fixes https://github.com/OP-TEE/build/issues/28.

In common.mk *_CLEAN_COMMON_FLAGS ?= *_COMMON_FLAGS but in the
platform makefiles (e.g. hikey.mk) they're defined as
such:
*_COMMON_FLAGS += x y z
*_CLEAN_COMMON_FLAGS += x

When expanded during a build, *_CLEAN_COMMON_FLAGS becomes
"x y z x". Variables can be repeated, which may be nothing more
than a cosmetic issue, but if any of those variables are make
targets, then 'make clean' will build them before cleaning.

To fix this, we remove the dependency of *_CLEAN_COMMON_FLAGS on
*_COMMON_FLAGS.

Signed-off-by: Victor Chong <victor.chong@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org> (hikey)