### PR TITLE
Use common rule for linux/.config and per-platform config fragments

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -70,6 +70,11 @@ LINUX_COMMON_FLAGS ?= LOCALVERSION= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL)
 linux-common: linux-defconfig
 	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS)
 
+$(LINUX_PATH)/.config: $(LINUX_DEFCONFIG_COMMON_FILES)
+	cd $(LINUX_PATH) && \
+		ARCH=$(LINUX_DEFCONFIG_COMMON_ARCH) \
+		scripts/kconfig/merge_config.sh $(LINUX_DEFCONFIG_COMMON_FILES)
+
 linux-defconfig-clean-common:
 	@rm -f $(LINUX_PATH)/.config
 

--- a/fvp.mk
+++ b/fvp.mk
@@ -89,10 +89,10 @@ edk2-clean: edk2-clean-common
 ################################################################################
 # Linux kernel
 ################################################################################
-$(LINUX_PATH)/.config:
-	# Temporary fix until we have the driver integrated in the kernel
-	sed -i '/config ARM64$$/a select DMA_SHARED_BUFFER' $(LINUX_PATH)/arch/arm64/Kconfig;
-	make -C $(LINUX_PATH) ARCH=arm64 defconfig
+LINUX_DEFCONFIG_COMMON_ARCH := arm64
+LINUX_DEFCONFIG_COMMON_FILES := \
+		$(LINUX_PATH)/arch/arm64/configs/defconfig \
+		$(CURDIR)/kconfigs/fvp.conf
 
 linux-defconfig: $(LINUX_PATH)/.config
 

--- a/hikey.mk
+++ b/hikey.mk
@@ -121,29 +121,9 @@ edk2-clean: edk2-clean-common
 ################################################################################
 # Linux kernel
 ################################################################################
-$(LINUX_PATH)/.config:
-	echo "# This file is merged with the kernel's default configuration" > $(LINUX_CONFIG_ADDLIST)
-	echo "# Disabling BTRFS gets rid of the RAID6 performance tests at boot time." >> $(LINUX_CONFIG_ADDLIST)
-	echo "# This shaves off a few seconds." >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_USB_NET_DM9601=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "# CONFIG_BTRFS_FS is not set" >> $(LINUX_CONFIG_ADDLIST)
-	echo "" >> $(LINUX_CONFIG_ADDLIST)
-	echo "# Enable ftrace as per https://github.com/OP-TEE/optee_os/blob/master/documentation/debug.md#2-ftrace" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_GENERIC_TRACER=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FTRACE=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FUNCTION_TRACER=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FUNCTION_GRAPH_TRACER=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FTRACE_SYSCALLS=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_BRANCH_PROFILE_NONE=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_STACK_TRACER=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_DYNAMIC_FTRACE=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FUNCTION_PROFILER=y" >> $(LINUX_CONFIG_ADDLIST)
-	echo "CONFIG_FTRACE_MCOUNT_RECORD=y" >> $(LINUX_CONFIG_ADDLIST)
-	cd $(LINUX_PATH); \
-	LOCALVERSION= \
-	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" \
-	ARCH=arm64 scripts/kconfig/merge_config.sh \
-    		arch/arm64/configs/defconfig $(LINUX_CONFIG_ADDLIST);
+LINUX_DEFCONFIG_COMMON_ARCH ?= arm64
+LINUX_DEFCONFIG_COMMON_FILES ?= $(LINUX_PATH)/arch/arm64/configs/defconfig \
+				$(CURDIR)/kconfigs/hikey.conf
 
 linux-defconfig: $(LINUX_PATH)/.config
 

--- a/kconfig_no_jffs2.conf
+++ b/kconfig_no_jffs2.conf
@@ -1,1 +1,0 @@
-# CONFIG_JFFS2_FS is not set

--- a/kconfig_preempt.conf
+++ b/kconfig_preempt.conf
@@ -1,1 +1,0 @@
-CONFIG_PREEMPT=y

--- a/kconfigs/fvp.conf
+++ b/kconfigs/fvp.conf
@@ -1,0 +1,1 @@
+CONFIG_DRM=y

--- a/kconfigs/hikey.conf
+++ b/kconfigs/hikey.conf
@@ -1,0 +1,1 @@
+CONFIG_DRM=y

--- a/kconfigs/mediatek.conf
+++ b/kconfigs/mediatek.conf
@@ -1,0 +1,1 @@
+CONFIG_DRM=y

--- a/kconfigs/qemu.conf
+++ b/kconfigs/qemu.conf
@@ -1,0 +1,4 @@
+CONFIG_DRM=y
+### These two lines prevent random failures of "make check" in Travis CI
+CONFIG_PREEMPT=y
+# CONFIG_JFFS2_FS is not set

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -48,10 +48,12 @@ $(LINUX_PATCH_PATH)/.patched:
 		$(LINUX_PATCH_PATH)/patch-all.sh
 	touch $@
 
+LINUX_DEFCONFIG_COMMON_ARCH := arm64
+LINUX_DEFCONFIG_COMMON_FILES := \
+                $(LINUX_PATH)/arch/arm64/configs/defconfig \
+                $(CURDIR)/kconfigs/mediatek.conf
+
 $(LINUX_PATH)/.config: $(LINUX_PATCH_PATH)/.patched
-	# Temporary fix until we have the driver integrated in the kernel
-	sed -i '/config ARM64$$/a select DMA_SHARED_BUFFER' $(LINUX_PATH)/arch/arm64/Kconfig;
-	make -C $(LINUX_PATH) ARCH=arm64 defconfig
 
 linux-defconfig: $(LINUX_PATH)/.config
 

--- a/qemu.mk
+++ b/qemu.mk
@@ -79,13 +79,10 @@ busybox-cleaner: busybox-cleaner-common
 ################################################################################
 # Linux kernel
 ################################################################################
-KCONFIGS := kconfig_preempt.conf kconfig_no_jffs2.conf
-$(LINUX_PATH)/.config: $(KCONFIGS)
-	# Temporary fix until we have the driver integrated in the kernel
-	sed -i '/config ARM$$/a select DMA_SHARED_BUFFER' $(LINUX_PATH)/arch/arm/Kconfig;
-	cd $(LINUX_PATH) && ARCH=arm scripts/kconfig/merge_config.sh \
-		arch/arm/configs/vexpress_defconfig \
-		$(patsubst %,$(CURDIR)/%,$(KCONFIGS))
+LINUX_DEFCONFIG_COMMON_ARCH := arm
+LINUX_DEFCONFIG_COMMON_FILES := \
+		$(LINUX_PATH)/arch/arm/configs/vexpress_defconfig \
+		$(CURDIR)/kconfigs/qemu.conf
 
 linux-defconfig: $(LINUX_PATH)/.config
 


### PR DESCRIPTION
- Kernel config fragments that were used by the QEMU makefile are
merged into kconfigs/qemu.conf. Now, each platform has its own file
in kconfigs/
- All platforms: CONFIG_DMA_SHARED_BUFFER cannot be enabled directly
because it is  a not a visible symbol (has no prompt in Kconfig).
CONFIG_DRM is set instead which depends on DMA.
- kconfigs/hikey.conf: keep only what is necessary

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>