### PR TITLE
FVP QEMU: Update with new TA dev kit name

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -10,7 +10,7 @@ CROSS_COMPILE_NS_KERNEL	?= "$(CCACHE)$(AARCH64_CROSS_COMPILE)"
 CROSS_COMPILE_S_USER	?= "$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 CROSS_COMPILE_S_KERNEL	?= "$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 OPTEE_OS_BIN		?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/core/tee.bin
-OPTEE_OS_TA_DEV_KIT_DIR	?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/export-user_ta
+OPTEE_OS_TA_DEV_KIT_DIR	?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/export-ta_arm32
 
 ################################################################################
 # Paths to git projects and various binaries

--- a/qemu.mk
+++ b/qemu.mk
@@ -15,7 +15,7 @@ CROSS_COMPILE_S_USER		?= "$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 CROSS_COMPILE_S_KERNEL		?= "$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 endif
 OPTEE_OS_BIN			?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/core/tee.bin
-OPTEE_OS_TA_DEV_KIT_DIR		?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/export-user_ta
+OPTEE_OS_TA_DEV_KIT_DIR		?= $(OPTEE_OS_PATH)/out/arm-plat-vexpress/export-ta_arm32
 
 ################################################################################
 # Paths to git projects and various binaries


### PR DESCRIPTION
Update with new TA dev kit name for FVP and QEMU.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Depends on https://github.com/OP-TEE/optee_os/pull/566