### PR TITLE
qemu: Add '-machine secure=on' to arguments

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -39,7 +39,7 @@ log_user 0
 # Save guest console output to a file
 log_file -a -noappend "serial0.log"
 info "Starting QEMU..."
-spawn ../qemu/arm-softmmu/qemu-system-arm -nographic -monitor none -machine virt -cpu cortex-a15 -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+spawn ../qemu/arm-softmmu/qemu-system-arm -nographic -monitor none -machine virt -machine secure=on virt -cpu cortex-a15 -m 1057 -serial stdio -serial file:serial1.log -bios $bios
 expect {
 	"Kernel panic" {
 		info "!!! Kernel panic\n"

--- a/qemu.mk
+++ b/qemu.mk
@@ -214,7 +214,7 @@ run-only:
 	$(QEMU_PATH)/arm-softmmu/qemu-system-arm \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
-		-s -S -machine virt -cpu cortex-a15 \
+		-s -S -machine virt -machine secure=on -cpu cortex-a15 \
 		-m 1057 \
 		-bios $(ROOT)/out/bios-qemu/bios.bin $(QEMU_EXTRA_ARGS)
 


### PR DESCRIPTION
This is required to move OP-TEE to upstream QEMU.

Signed-off-by: Victor Chong <victor.chong@linaro.org>
Suggested-by: Peter Maydell <peter.maydell@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org>