### PR TITLE
common: Fix optee_linuxdriver clean target

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -239,8 +239,7 @@ OPTEE_LINUXDRIVER_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
 optee-linuxdriver-common: linux
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_COMMON_FLAGS) modules
 
-# OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS can be defined in specific makefiles
-# (hikey.mk,...) if necessary
+OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS ?= M=$(OPTEE_LINUXDRIVER_PATH)
 
 optee-linuxdriver-clean-common:
 	$(MAKE) -C $(LINUX_PATH) $(OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS) clean


### PR DESCRIPTION
OPTEE_LINUXDRIVER_CLEAN_COMMON_FLAGS needs to specify the module M
flag, else linux is cleaned instead of optee_linuxdriver.

Signed-off-by: Victor Chong <victor.chong@linaro.org>