### PR TITLE
kconfigs/qemu.conf: restore '# CONFIG_JFFS2_FS is disabled'

### DIFF
--- a/kconfigs/qemu.conf
+++ b/kconfigs/qemu.conf
@@ -1,4 +1,6 @@
 CONFIG_TEE=y
 CONFIG_OPTEE=y
-### This prevents random failures of "make check" in Travis CI
+### Enabling PREEMPT and disabling JFFS2_FS prevents random failures of
+### "make check" in Travis CI
 CONFIG_PREEMPT=y
+CONFIG_JFFS2_FS=n


### PR DESCRIPTION
The line disabling CONFIG_JFFS2_FS was removed by mistake by commit
a6d968c8bc63 ("qemu: generic driver"). Restore it to fix the Travis
tests.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>