### PR TITLE
gcc5: Update to use gcc5

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -39,7 +39,7 @@ all-clean: arm-tf-clean busybox-clean edk2-clean optee-os-clean \
 ################################################################################
 ARM_TF_EXPORTS ?= \
 	CFLAGS="-O0 -gdwarf-2" \
-	CROSS_COMPILE="$(CCACHE)$(AARCH64_NONE_CROSS_COMPILE)"
+	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)"
 
 ARM_TF_FLAGS ?= \
 	BL32=$(OPTEE_OS_BIN) \
@@ -71,7 +71,7 @@ busybox-cleaner: busybox-cleaner-common
 # EDK2 / Tianocore
 ################################################################################
 define edk2-call
-	GCC49_AARCH64_PREFIX=$(AARCH64_NONE_CROSS_COMPILE) \
+	GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
 	     $(MAKE) -j1 -C $(EDK2_PATH) \
 	     -f ArmPlatformPkg/Scripts/Makefile EDK2_ARCH=AARCH64 \
 	     EDK2_DSC=ArmPlatformPkg/ArmVExpressPkg/ArmVExpress-FVP-AArch64.dsc \
@@ -132,13 +132,6 @@ xtest-patch: xtest-patch-common
 ################################################################################
 # Root FS
 ################################################################################
-ifeq ($(COMPILE_NS_USER),32)
-ROOTFS_LIBPATH	?= "/lib/arm-linux-gnueabihf"
-endif
-ifeq ($(COMPILE_NS_USER),64)
-ROOTFS_LIBPATH	?= "/lib/aarch64-linux-gnu"
-endif
-
 .PHONY: filelist-tee
 filelist-tee:
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
@@ -158,10 +151,9 @@ filelist-tee:
 	fi
 	@echo "# OP-TEE Client" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /bin/tee-supplicant $(OPTEE_CLIENT_EXPORT)/bin/tee-supplicant 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "dir $(ROOTFS_LIBPATH) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file $(ROOTFS_LIBPATH)/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink $(ROOTFS_LIBPATH)/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink $(ROOTFS_LIBPATH)/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
 update_rootfs: busybox optee-client xtest filelist-tee
 	cat $(GEN_ROOTFS_PATH)/filelist-final.txt $(GEN_ROOTFS_PATH)/filelist-tee.txt > $(GEN_ROOTFS_PATH)/filelist.tmp

--- a/hikey.mk
+++ b/hikey.mk
@@ -130,7 +130,7 @@ ifeq ($(EDK2_CONSOLE_UART),0)
 endif
 
 define edk2-call
-	GCC49_AARCH64_PREFIX=$(AARCH64_CROSS_COMPILE) \
+	GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
 	$(MAKE) -j1 -C $(EDK2_PATH) \
 		-f HisiPkg/HiKeyPkg/Makefile $(EDK2_VARS)
 endef

--- a/juno.mk
+++ b/juno.mk
@@ -35,7 +35,7 @@ all-clean: arm-tf-clean busybox-clean u-boot-clean optee-os-clean \
 ################################################################################
 ARM_TF_EXPORTS ?= \
 	CFLAGS="-O0 -gdwarf-2" \
-	CROSS_COMPILE="$(CCACHE)$(AARCH64_NONE_CROSS_COMPILE)"
+	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)"
 
 ARM_TF_FLAGS ?= \
 	SCP_BL2=$(ROOT)/vexpress-firmware/SOFTWARE/bl30.bin \
@@ -150,10 +150,9 @@ filelist-tee:
 	fi
 	@echo "# OP-TEE Client" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /bin/tee-supplicant $(OPTEE_CLIENT_EXPORT)/bin/tee-supplicant 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "dir /lib/aarch64-linux-gnu 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /lib/aarch64-linux-gnu/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink /lib/aarch64-linux-gnu/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink /lib/aarch64-linux-gnu/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
 .PHONY: update_rootfs
 update_rootfs: u-boot busybox optee-client xtest filelist-tee

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -33,7 +33,7 @@ all-clean: arm-tf-clean linux-clean busybox-clean optee-os-clean \
 ################################################################################
 ARM_TF_EXPORTS ?= \
 	CFLAGS="-O0 -gdwarf-2" \
-	CROSS_COMPILE="$(CCACHE)$(AARCH64_NONE_CROSS_COMPILE)"
+	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)"
 
 ARM_TF_FLAGS ?= \
 	DEBUG=1 \

--- a/qemu.mk
+++ b/qemu.mk
@@ -144,10 +144,9 @@ filelist-tee: xtest
 	fi
 	@echo "# OP-TEE Client" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /bin/tee-supplicant $(OPTEE_CLIENT_EXPORT)/bin/tee-supplicant 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "dir /lib/arm-linux-gnueabihf 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /lib/arm-linux-gnueabihf/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink /lib/arm-linux-gnueabihf/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "slink /lib/arm-linux-gnueabihf/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/libteec.so.1.0 $(OPTEE_CLIENT_EXPORT)/lib/libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "slink /lib/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
 update_rootfs: busybox optee-client filelist-tee
 	cat $(GEN_ROOTFS_PATH)/filelist-final.txt $(GEN_ROOTFS_PATH)/filelist-tee.txt > $(GEN_ROOTFS_PATH)/filelist.tmp

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -6,18 +6,20 @@ TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
 AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
-AARCH32_GCC_VERSION 		?= gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux
-SRC_AARCH32_GCC 		?= http://releases.linaro.org/14.08/components/toolchain/binaries/${AARCH32_GCC_VERSION}.tar.xz
+AARCH32_GCC_VERSION 		?= gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf
+SRC_AARCH32_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/arm-linux-gnueabihf/${AARCH32_GCC_VERSION}.tar.xz
 
 AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
 AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
-AARCH64_GCC_VERSION 		?= gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
-SRC_AARCH64_GCC 		?= http://releases.linaro.org/14.08/components/toolchain/binaries/${AARCH64_GCC_VERSION}.tar.xz
+AARCH64_GCC_VERSION 		?= gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu
+SRC_AARCH64_GCC 		?= https://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/aarch64-linux-gnu/${AARCH64_GCC_VERSION}.tar.xz
 
-AARCH64_NONE_PATH 		?= $(TOOLCHAIN_ROOT)/aarch64-none-elf
-AARCH64_NONE_CROSS_COMPILE 	?= $(AARCH64_NONE_PATH)/bin/aarch64-none-elf-
-AARCH64_NONE_GCC_VERSION 	?= gcc-linaro-aarch64-none-elf-4.9-2014.07_linux
-SRC_AARCH64_NONE_GCC 		?= http://releases.linaro.org/14.07/components/toolchain/binaries/${AARCH64_NONE_GCC_VERSION}.tar.xz
+# Due to relocation error on the 96board edk forest, let's keep the old
+# toolchain for a while.
+LEGACY_AARCH64_PATH             ?= $(TOOLCHAIN_ROOT)/aarch64-legacy
+LEGACY_AARCH64_CROSS_COMPILE    ?= $(LEGACY_AARCH64_PATH)/bin/aarch64-linux-gnu-
+LEGACY_AARCH64_GCC_VERSION      ?= gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
+LEGACY_SRC_AARCH64_GCC          ?= http://releases.linaro.org/14.08/components/toolchain/binaries/${LEGACY_AARCH64_GCC_VERSION}.tar.xz
 
 toolchains:
 	mkdir -p $(AARCH32_PATH)
@@ -28,7 +30,7 @@ toolchains:
 	curl -L $(SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz
 	tar xf $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz -C $(AARCH64_PATH) --strip-components=1
 
-	mkdir -p $(AARCH64_NONE_PATH)
-	curl -L $(SRC_AARCH64_NONE_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH64_NONE_GCC_VERSION).tar.xz
-	tar xf $(TOOLCHAIN_ROOT)/$(AARCH64_NONE_GCC_VERSION).tar.xz -C $(AARCH64_NONE_PATH) --strip-components=1
+	mkdir -p $(LEGACY_AARCH64_PATH)
+	curl -L $(LEGACY_SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz
+	tar xf $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz -C $(LEGACY_AARCH64_PATH) --strip-components=1
 


### PR DESCRIPTION
- Adds legacy toolchain for use in older edk2 projects, this is the only
  project using the pre 5.x toolchain for now
- Removes the bare metal toolchain
- qemu: Change the path for libraries for GCC5
- fvp: compiler changes for ARM-TF and EDK2
       Update libteec path in initramfs
- mtk: Toolchain and libteec path updates
- juno: Toolchain and libteec path updates

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU, FVP, HiKey)