### PR TITLE
Add support for hello_world TA

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14,6 +14,7 @@ OPTEE_CLIENT_PATH		?= $(ROOT)/optee_client
 OPTEE_CLIENT_EXPORT		?= $(OPTEE_CLIENT_PATH)/out/export
 OPTEE_TEST_PATH			?= $(ROOT)/optee_test
 OPTEE_TEST_OUT_PATH 		?= $(ROOT)/optee_test/out
+HELLOWORLD_PATH			?= $(ROOT)/hello_world
 
 CFG_TEE_CORE_LOG_LEVEL		?= 3
 
@@ -194,7 +195,7 @@ optee-os-common:
 
 OPTEE_OS_CLEAN_COMMON_FLAGS ?= $(OPTEE_OS_COMMON_EXTRA_FLAGS)
 
-optee-os-clean-common: xtest-clean
+optee-os-clean-common: xtest-clean helloworld-clean
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_CLEAN_COMMON_FLAGS) clean
 
 OPTEE_CLIENT_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)
@@ -231,3 +232,19 @@ XTEST_PATCH_COMMON_FLAGS ?= $(XTEST_COMMON_FLAGS)
 
 xtest-patch-common:
 	$(MAKE) -C $(OPTEE_TEST_PATH) $(XTEST_PATCH_COMMON_FLAGS) patch
+
+################################################################################
+# hello_world
+################################################################################
+HELLOWORLD_COMMON_FLAGS ?= HOST_CROSS_COMPILE=$(CROSS_COMPILE_NS_USER)\
+	TA_CROSS_COMPILE=$(CROSS_COMPILE_S_USER) \
+	TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR) \
+	TEEC_EXPORT=$(OPTEE_CLIENT_EXPORT)
+
+helloworld-common: optee-os optee-client
+	$(MAKE) -C $(HELLOWORLD_PATH) $(HELLOWORLD_COMMON_FLAGS)
+
+HELLOWORLD_CLEAN_COMMON_FLAGS ?= TA_DEV_KIT_DIR=$(OPTEE_OS_TA_DEV_KIT_DIR)
+
+helloworld-clean-common:
+	$(MAKE) -C $(HELLOWORLD_PATH) $(HELLOWORLD_CLEAN_COMMON_FLAGS) clean

--- a/fvp.mk
+++ b/fvp.mk
@@ -27,7 +27,7 @@ endif
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf edk2 linux optee-os optee-client xtest
+all: arm-tf edk2 linux optee-os optee-client xtest helloworld
 all-clean: arm-tf-clean busybox-clean edk2-clean optee-os-clean \
 	optee-client-clean
 
@@ -130,17 +130,26 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # Root FS
 ################################################################################
 .PHONY: filelist-tee
 filelist-tee:
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# TAs" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /lib/optee_armtz 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
 		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_FILELIST)
-	@echo "# Secure storage dig" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "# Secure storage dir" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data/tee 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \
@@ -155,7 +164,7 @@ filelist-tee:
 	@echo "slink /lib/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "slink /lib/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
-update_rootfs: busybox optee-client xtest filelist-tee
+update_rootfs: busybox optee-client xtest helloworld filelist-tee
 	cat $(GEN_ROOTFS_PATH)/filelist-final.txt $(GEN_ROOTFS_PATH)/filelist-tee.txt > $(GEN_ROOTFS_PATH)/filelist.tmp
 	cd $(GEN_ROOTFS_PATH); \
 	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist.tmp | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz

--- a/hikey.mk
+++ b/hikey.mk
@@ -61,7 +61,7 @@ SHAPERF_PATH			?=$(ROOT)/sha-perf
 ################################################################################
 all: prepare arm-tf boot-img lloader nvme
 
-clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean strace-clean update_rootfs-clean boot-img-clean lloader-clean aes-perf-clean sha-perf-clean grub-clean
+clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean helloworld-clean strace-clean update_rootfs-clean boot-img-clean lloader-clean aes-perf-clean sha-perf-clean grub-clean
 
 cleaner: clean prepare-cleaner busybox-cleaner linux-cleaner strace-cleaner nvme-cleaner grub-cleaner
 
@@ -215,6 +215,13 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # aes-pef
 ################################################################################
 PERF_FLAGS := CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER) \
@@ -271,8 +278,10 @@ filelist-all: busybox
 	export TOP=$(ROOT); export MULTIARCH=$(MULTIARCH); \
 	$(expand-env-var) <$(PATCHES_PATH)/rootfs/initramfs-add-files.txt >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
 	find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
 	find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
-		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_PATH)/filelist-all.txt
+		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt
 	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \
 		echo "# OP-TEE device" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
 		echo "dir /lib/modules 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
@@ -280,7 +289,7 @@ filelist-all: busybox
 		echo "file /lib/modules/$(call KERNEL_VERSION)/optee.ko $(OPTEE_GENDRV_MODULE) 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
 	fi
 
-update_rootfs: optee-client xtest aes-perf sha-perf strace filelist-all linux-gen_init_cpio
+update_rootfs: optee-client xtest helloworld aes-perf sha-perf strace filelist-all linux-gen_init_cpio
 	cd $(GEN_ROOTFS_PATH); \
 	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist-all.txt | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz
 

--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -81,7 +81,7 @@ DEBPKG_CONTROL_PATH		?= $(DEBPKG_PATH)/DEBIAN
 ################################################################################
 all: prepare arm-tf linux boot-img lloader system-img nvme deb
 
-clean: arm-tf-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean boot-img-clean lloader-clean aes-perf-clean sha-perf-clean
+clean: arm-tf-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean helloworld-clean boot-img-clean lloader-clean aes-perf-clean sha-perf-clean
 
 cleaner: clean prepare-cleaner linux-cleaner nvme-cleaner system-img-cleaner
 
@@ -213,6 +213,13 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # aes-pef
 ################################################################################
 PERF_FLAGS := CROSS_COMPILE_HOST=$(CROSS_COMPILE_NS_USER) \
@@ -301,7 +308,7 @@ Architecture: arm64
 Depends:
 Maintainer: Joakim Bech <joakim.bech@linaro.org>
 Description: OP-TEE client binaries, test program and Trusted Applications
- Package contains tee-supplicant, libtee.so, xtest and a set of
+ Package contains tee-supplicant, libtee.so, xtest, hello_world and a set of
  Trusted Applications.
  NOTE! This package should only be used for testing and development.
 endef
@@ -309,15 +316,17 @@ endef
 export CONTROL_TEXT
 
 .PHONY: deb
-deb: xtest optee-client
+deb: xtest helloworld optee-client
 	@mkdir -p $(DEBPKG_BIN_PATH) && cd $(DEBPKG_BIN_PATH) && \
 		cp -f $(OPTEE_CLIENT_EXPORT)/bin/tee-supplicant . && \
-		cp -f $(OPTEE_TEST_OUT_PATH)/xtest/xtest .
+		cp -f $(OPTEE_TEST_OUT_PATH)/xtest/xtest . && \
+		cp -f $(HELLOWORLD_PATH)/host/hello_world .
 
 	@mkdir -p $(DEBPKG_LIB_PATH) && cd $(DEBPKG_LIB_PATH) && \
 		cp $(OPTEE_CLIENT_EXPORT)/lib/libtee* .
 
 	@mkdir -p $(DEBPKG_TA_PATH) && cd $(DEBPKG_TA_PATH) && \
+		cp $(HELLOWORLD_PATH)/ta/*.ta . && \
 		find $(OPTEE_TEST_OUT_PATH)/ta -name "*.ta" -exec cp {} . \;
 
 	@mkdir -p $(DEBPKG_CONTROL_PATH)

--- a/juno.mk
+++ b/juno.mk
@@ -23,7 +23,7 @@ U-BOOT_BIN		?= $(U-BOOT_PATH)/u-boot.bin
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf u-boot linux optee-os optee-client xtest update_rootfs
+all: arm-tf u-boot linux optee-os optee-client xtest helloworld update_rootfs
 all-clean: arm-tf-clean busybox-clean u-boot-clean optee-os-clean \
 	optee-client-clean
 
@@ -129,17 +129,26 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # Root FS
 ################################################################################
 .PHONY: filelist-tee
 filelist-tee:
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# TAs" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /lib/optee_armtz 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
 		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_FILELIST)
-	@echo "# Secure storage dig" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "# Secure storage dir" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data/tee 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \
@@ -155,7 +164,7 @@ filelist-tee:
 	@echo "slink /lib/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
 .PHONY: update_rootfs
-update_rootfs: u-boot busybox optee-client xtest filelist-tee
+update_rootfs: u-boot busybox optee-client xtest helloworld filelist-tee
 	cat $(GEN_ROOTFS_PATH)/filelist-final.txt $(GEN_ROOTFS_PATH)/filelist-tee.txt > $(GEN_ROOTFS_PATH)/filelist.tmp
 	cd $(GEN_ROOTFS_PATH) && \
 	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist.tmp | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -21,7 +21,7 @@ ARM_TF_BIN			?= $(ARM_TF_PATH)/build/mt8173/debug/bl31.bin
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf linux optee-os optee-client xtest
+all: arm-tf linux optee-os optee-client xtest helloworld
 all-clean: arm-tf-clean linux-clean busybox-clean optee-os-clean \
 	optee-client-clean
 
@@ -104,17 +104,25 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # Root FS
 ################################################################################
 .PHONY: filelist-tee
 filelist-tee:
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# TAs" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /lib/optee_armtz 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
 		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_FILELIST)
-	@echo "# Secure storage dig" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "# Secure storage dir" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data/tee 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \
@@ -130,7 +138,7 @@ filelist-tee:
 	@echo "slink /lib/aarch64-linux-gnu/libteec.so.1 libteec.so.1.0 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "slink /lib/aarch64-linux-gnu/libteec.so libteec.so.1 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 
-update_rootfs: busybox optee-client xtest filelist-tee
+update_rootfs: busybox optee-client xtest helloworld filelist-tee
 	cat $(GEN_ROOTFS_PATH)/filelist-final.txt $(GEN_ROOTFS_PATH)/filelist-tee.txt > $(GEN_ROOTFS_PATH)/filelist.tmp
 	cd $(GEN_ROOTFS_PATH); \
 	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist.tmp | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz

--- a/qemu.mk
+++ b/qemu.mk
@@ -123,17 +123,26 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # Root FS
 ################################################################################
 .PHONY: filelist-tee
-filelist-tee: xtest
+filelist-tee: xtest helloworld
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# TAs" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /lib/optee_armtz 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
 		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_FILELIST)
-	@echo "# Secure storage dig" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "# Secure storage dir" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data/tee 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -151,6 +151,13 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
+# hello_world
+################################################################################
+helloworld: helloworld-common
+
+helloworld-clean: helloworld-clean-common
+
+################################################################################
 # strace
 ################################################################################
 strace:
@@ -172,13 +179,15 @@ endif
 # Root FS
 ################################################################################
 .PHONY: filelist-tee
-filelist-tee: xtest
+filelist-tee: xtest helloworld
 	@echo "# xtest / optee_test" > $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# TAs" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /lib/optee_armtz 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
 		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "# Secure storage dir" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "dir /data/tee 755 0 0" >> $(GEN_ROOTFS_FILELIST)


### PR DESCRIPTION
Many users are still using https://github.com/jenswi-linaro/lcu14_optee_hello_world as a reference to start writing TAs, probably because diving directly into xtest requires some effort, but since lcu14_optee_hello_world is not maintained, it can make supporting these users difficult, so add to our build system a maintained version of hello_world TA, i.e. https://github.com/linaro-swg/hello_world.

Signed-off-by: Victor Chong <victor.chong@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org> (qemu)