### PR TITLE
qemu: Ability to switch Python version for QEMU

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -18,6 +18,8 @@ QEMU_PATH			?= $(ROOT)/qemu
 
 SOC_TERM_PATH			?= $(ROOT)/soc_term
 
+PYTHON_PATH			?= $(shell which python)
+
 DEBUG = 1
 
 ################################################################################
@@ -49,7 +51,7 @@ bios-qemu-clean:
 	$(call bios-qemu-common) clean
 
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error"
+	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error" --python="$(PYTHON_PATH)"
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:


### PR DESCRIPTION
On some distros /usr/bin/python points to Python 3.x and changing that
to point to Python 2.x might not be an easy thing to do. By adding the
variable PYTHON_PATH one can easily change the python version to be used
with QEMU (QEMU only supports Python 2.x).

For a distro where Python 3.x is the default one could/should call make
like this:

 $ PYTHON_PATH=/usr/bin/python2 make

Signed-off-by: Joakim Bech joakim.bech@linaro.org
