### PR TITLE
qemu_v8: replace broken edk2 link

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -65,7 +65,7 @@ edk2: optee-os
 ifeq ("$(wildcard $(EDK2_BIN))","")
 	mkdir -p $(EDK2_PATH)
 	wget -O $(EDK2_BIN) \
-		http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/989/QEMU-KERNEL-AARCH64/RELEASE_GCC49/QEMU_EFI.fd
+		http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/716/QEMU-KERNEL-AARCH64/RELEASE_GCC49/QEMU_EFI.fd
 endif
 	mkdir -p $(ARM_TF_PATH)/build/qemu/release
 	ln -sf $(OPTEE_OS_BIN) $(ARM_TF_PATH)/build/qemu/release/bl32.bin


### PR DESCRIPTION
Replaces broken edk2 link with a slightly older but working link.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>