### PR TITLE
qemu-check.exp: monitor TEE core log file and detect assertion failures

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -39,6 +39,9 @@ log_user 0
 # Save guest console output to a file
 log_file -a -noappend "serial0.log"
 info "Starting QEMU..."
+open "serial1.log" "w+"
+spawn -open [open "|tail -f serial1.log"]
+set teecore $spawn_id
 spawn ../qemu/arm-softmmu/qemu-system-arm -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -m 1057 -serial stdio -serial file:serial1.log -bios $bios
 expect {
 	"Kernel panic" {
@@ -93,6 +96,11 @@ expect {
 	}
 	# Exit when result separator is seen
 	"+-----------------------------------------------------\r\r" {}
+	# Handle errors in TEE core output
+	-i $teecore -re {(assertion.*failed at.*)\n} {
+		info "!!! TEE core assertion failed: '$expect_out(1,string)'\n"
+		exit 1
+	}
 	timeout {
 		info "!!! Timeout\n"
 		info "TIMEOUT - test case too long or hung? (last test started: $casenum)\n"


### PR DESCRIPTION
When "make check" is run and an assertion fails in TEE core, secure
world hangs, and therefore xtest hangs too. "make check" will not
report the failure and exit until a timeout occurs (480s).
In order to detect the error condition sooner, open the TEE core log
file and add a trigger on "assertion ... failed at ...".

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>