### PR TITLE
Fix toolchain.mk ROOT path

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -1,7 +1,7 @@
 ################################################################################
 # Toolchains
 ################################################################################
-ROOT				?= ${HOME}/devel/optee
+ROOT					?= $(CURDIR)/..
 TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32


### PR DESCRIPTION
Change path to relative to current dir, the same as in common.mk

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`
