### PR TITLE
toolchain.mk: Update legacy toolchain download url

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -19,7 +19,7 @@ SRC_AARCH64_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/5.
 LEGACY_AARCH64_PATH             ?= $(TOOLCHAIN_ROOT)/aarch64-legacy
 LEGACY_AARCH64_CROSS_COMPILE    ?= $(LEGACY_AARCH64_PATH)/bin/aarch64-linux-gnu-
 LEGACY_AARCH64_GCC_VERSION      ?= gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
-LEGACY_SRC_AARCH64_GCC          ?= http://releases.linaro.org/14.08/components/toolchain/binaries/${LEGACY_AARCH64_GCC_VERSION}.tar.xz
+LEGACY_SRC_AARCH64_GCC          ?= http://releases.linaro.org/archive/14.08/components/toolchain/binaries/${LEGACY_AARCH64_GCC_VERSION}.tar.xz
 
 toolchains:
 	mkdir -p $(AARCH32_PATH)


### PR DESCRIPTION
Fixes https://github.com/OP-TEE/optee_os/issues/1195.

Signed-off-by: Victor Chong <victor.chong@linaro.org>