### PR TITLE
Fix incorrect UUID for hello world TA

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -296,8 +296,8 @@ filelist-tee-common: optee-client xtest helloworld
 	@if [ -e $(HELLOWORLD_PATH)/host/hello_world ]; then \
 		echo "file /bin/hello_world" \
 			"$(HELLOWORLD_PATH)/host/hello_world 755 0 0"	>> $(fl); \
-		echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta" \
-			"$(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta" \
+		echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe2-0002a5d5c51b.ta" \
+			"$(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe2-0002a5d5c51b.ta" \
 			"444 0 0" 					>> $(fl); \
 	fi
 	@echo "# Secure storage dir" 					>> $(fl)


### PR DESCRIPTION
With the recently fixed UUID changes (commit in optee_os:
(9a8a19cdba48dbca89c2a35d7984e9ec28f97bda) we missed to fix the hello
world TA.

Depends on https://github.com/linaro-swg/hello_world/pull/6

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>