### PR TITLE
U-Boot env bootargs cleanup

### DIFF
--- a/rpi3/firmware/uboot.env.txt
+++ b/rpi3/firmware/uboot.env.txt
@@ -1,28 +1,41 @@
+# generic params
 bootdelay=3
-atf_load_addr=0x08400000
-atf_file=optee.bin
-baudrate=115200
-boot_it=booti ${kernel_addr_r} - ${fdt_addr_r}
-bootargs=console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootfs=ext4 ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes smsc95xx.macaddr=${ethaddr} bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000
-bootcmd=run load_kernel; run load_dtb; run load_firmware; run boot_it
-bootdelay=2
-cpu=armv8
-fdt_addr_r=0x1700000
-fdtfile=bcm2710-rpi-3-b.dtb
-filesize=5a65c
-gatewayip=192.168.1.1
-initrd_high=ffffffff
-kernel_addr_r=0x10000000
-load_dtb=fatload mmc 0:1 ${fdt_addr_r} ${fdtfile}
-load_firmware=fatload mmc 0:1 ${atf_load_addr} ${atf_file}
-load_kernel=fatload mmc 0:1 ${kernel_addr_r} Image
-netmask=255.255.255.0
-serverip=192.168.1.164
-smp=on
 stderr=serial,lcd
 stdin=serial,usbkbd
 stdout=serial,lcd
 
-#setenv optee 'usb start; dhcp ${kernel_addr_r} 192.168.1.164:Image; dhcp ${fdt_addr_r} 192.168.1.164:${fdtfile}; dhcp ${atf_load_addr} 192.168.1.164:${atf_file}; run boot_it'
+# CPU config
+cpu=armv8
+smp=on
 
-#setenv bootargs 'console=ttyS0,115200 root=/dev/nfs rw rootfstype=nfs nfsroot=192.168.1.164:/mnt/sshd/srv/nfs/debian-arm64,udp,vers=3 ip=dhcp ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes smsc95xx.macaddr=${ethaddr} bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000'
+# Console config
+baudrate=115200
+ttyconsole=ttyS0
+
+# Kernel/firmware/dtb filenames & load addresses
+atf_load_addr=0x08400000
+atf_file=optee.bin
+boot_it=booti ${kernel_addr_r} - ${fdt_addr_r}
+fdt_addr_r=0x1700000
+fdtfile=bcm2710-rpi-3-b.dtb
+filesize=5a65c
+initrd_high=ffffffff
+kernel_addr_r=0x10000000
+
+# NFS/TFTP boot configuraton
+gatewayip=192.168.1.1
+netmask=255.255.255.0
+serverip=192.168.1.5
+nfspath=/opt/linaro/nfs
+
+# bootcmd & bootargs configuration
+bootcmd=run mmcboot
+load_dtb=fatload mmc 0:1 ${fdt_addr_r} ${fdtfile}
+load_firmware=fatload mmc 0:1 ${atf_load_addr} ${atf_file}
+load_kernel=fatload mmc 0:1 ${kernel_addr_r} Image
+mmcboot=run load_kernel; run load_dtb; run load_firmware; run set_bootargs_tty set_bootargs_mmc set_common_args; run boot_it
+nfsboot=usb start; dhcp ${kernel_addr_r} ${serverip}:Image; dhcp ${fdt_addr_r} ${serverip}:${fdtfile}; dhcp ${atf_load_addr} ${serverip}:${atf_file}; run set_bootargs_tty set_bootargs_nfs set_common_args; run boot_it
+set_bootargs_tty=setenv bootargs console=${ttyconsole},${baudrate}
+set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${serverip}:${nfspath},udp,vers=3 ip=dhcp
+set_bootargs_mmc=setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfs=ext4
+set_common_args=setenv bootargs ${bootargs} ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes smsc95xx.macaddr=${ethaddr} 'bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000'


### PR DESCRIPTION
Add runtime kernel comandline creation (for both mmc/nfs boot)
The same as described in http://wiki.dave.eu/index.php/Change_Linux_Command_Line_Parameter_from_U-boot
Minor: reordered vars (just grouped it a bit)

Type (default Boot sequence) `run mmcboot` to load `Image`/`optee.bin`/dtb file/mount rootfs from MMC
Type `run nfsboot` to download `Image`/`optee.bin`/dtb file from TFTP server/mount rootfs over NFS


BTW, I'll also add patches to documentation/rpi3.md tomorrow 

```
Tested-by: Igor Opaniuk <igor.opaniuk@linaro.org> (rpi3)
Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>
```