### PR TITLE
hikey: Use common rules for TAs etc

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -59,7 +59,7 @@ SHAPERF_PATH			?=$(ROOT)/sha-perf
 ################################################################################
 # Targets
 ################################################################################
-all: prepare arm-tf boot-img lloader nvme
+all: prepare arm-tf boot-img lloader nvme strace
 
 clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean helloworld-clean strace-clean update_rootfs-clean boot-img-clean lloader-clean aes-perf-clean sha-perf-clean grub-clean
 
@@ -272,28 +272,15 @@ define expand-env-var
 awk '{while(match($$0,"[$$]{[^}]*}")) {var=substr($$0,RSTART+2,RLENGTH -3);gsub("[$$]{"var"}",ENVIRON[var])}}1'
 endef
 
-filelist-all: busybox
-	@cat $(GEN_ROOTFS_PATH)/filelist-final.txt | sed '/fbtest/d' > $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@env TOP=$(ROOT) $(expand-env-var) <$(PATCHES_PATH)/rootfs/initramfs-add-files.txt >> $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@find $(OPTEE_TEST_OUT_PATH) -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >> $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@echo "file /bin/hello_world $(HELLOWORLD_PATH)/host/hello_world 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@find $(OPTEE_TEST_OUT_PATH) -name "*.ta" | \
-		sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >> $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@echo "file /lib/optee_armtz/8aaaf200-2450-11e4-abe20002a5d5c51b.ta $(HELLOWORLD_PATH)/ta/8aaaf200-2450-11e4-abe20002a5d5c51b.ta 444 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt
-	@if [ -e $(OPTEE_GENDRV_MODULE) ]; then \
-		echo "# OP-TEE device" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
-		echo "dir /lib/modules 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
-		echo "dir /lib/modules/$(call KERNEL_VERSION) 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
-		echo "file /lib/modules/$(call KERNEL_VERSION)/optee.ko $(OPTEE_GENDRV_MODULE) 755 0 0" >> $(GEN_ROOTFS_PATH)/filelist-all.txt; \
-	fi
+.PHONY: filelist-tee
+filelist-tee: filelist-tee-common
+	env TOP=$(ROOT) $(expand-env-var) <$(PATCHES_PATH)/rootfs/initramfs-add-files.txt >> $(GEN_ROOTFS_FILELIST)
 
-update_rootfs: optee-client xtest helloworld aes-perf sha-perf strace filelist-all linux-gen_init_cpio
-	cd $(GEN_ROOTFS_PATH); \
-	        $(LINUX_PATH)/usr/gen_init_cpio $(GEN_ROOTFS_PATH)/filelist-all.txt | gzip > $(GEN_ROOTFS_PATH)/filesystem.cpio.gz
+.PHONY: update_rootfs
+update_rootfs: update_rootfs-common
 
 .PHONY: update_rootfs-clean
-update_rootfs-clean:
-	rm -f $(GEN_ROOTFS_PATH)/filesystem.cpio.gz $(GEN_ROOTFS_PATH)/filelist-all.txt $(GEN_ROOTFS_PATH)/filelist-tmp.txt
+update_rootfs-clean: update_rootfs-clean-common
 
 ################################################################################
 # grub


### PR DESCRIPTION
It seems like there where some leftovers from the consolidation of the
filesystem generation patches a while ago. This cleans up duplicates
etc and fixes an error when generating the root fs due to recent
changes.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>