### PR TITLE
hikey*.mk: Remove unsafe 'rm -rf' commands

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -137,7 +137,7 @@ busybox-clean-common:
 
 busybox-cleaner-common:
 	rm -rf $(GEN_ROOTFS_PATH)/build
-	rm -rf $(GEN_ROOTFS_PATH)/filelist-final.txt
+	rm -f $(GEN_ROOTFS_PATH)/filelist-final.txt
 
 ################################################################################
 # Linux

--- a/hikey.mk
+++ b/hikey.mk
@@ -209,7 +209,6 @@ xtest: xtest-common
 # "make clean" in xtest: fails if optee_os has been cleaned previously
 .PHONY: xtest-clean
 xtest-clean: xtest-clean-common
-	rm -rf $(OPTEE_TEST_OUT_PATH)
 
 .PHONY: xtest-patch
 xtest-patch: xtest-patch-common

--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -207,7 +207,6 @@ xtest: xtest-common
 # "make clean" in xtest: fails if optee_os has been cleaned previously
 .PHONY: xtest-clean
 xtest-clean: xtest-clean-common
-	rm -rf $(OPTEE_TEST_OUT_PATH)
 
 .PHONY: xtest-patch
 xtest-patch: xtest-patch-common


### PR DESCRIPTION
If OPTEE_TEST_OUT_PATH is redefined to some critical path/patterns, important
files might be deleted, so remove these commands which are not present on
other platforms anyway.

Also a minor change in common.mk from 'rm -rf' to 'rm -f' to remove
unnecessary recursion.

Signed-off-by: Victor Chong <victor.chong@linaro.org>