### PR TITLE
docs: fix broken links to README.md

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -295,5 +295,5 @@ $ echo 0 > options/graph-time
    breakpoints before booting up the system.
 
 [Affinic Debugger]: http://www.affinic.com/?page_id=109
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md
 [QEMU ARMv7-A]: qemu.md#3-qemu-console

--- a/docs/fvp.md
+++ b/docs/fvp.md
@@ -19,4 +19,4 @@ $ make run
 And the FVP should build the root fs and then start the simulation.
 
 [Foundation Models binaries]: https://developer.arm.com/products/system-design/fixed-virtual-platforms
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md

--- a/docs/hikey.md
+++ b/docs/hikey.md
@@ -140,6 +140,6 @@ $ make recovery
 [AOSP HiKey branch]: https://source.android.com/source/devices.html
 [official HiKey documentation]: http://www.96boards.org/documentation/ConsumerEdition/HiKey/README.md
 [OP-TEE Android Manifest]: https://github.com/linaro-swg/optee_android_manifest
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md
 [UART in hikey.mk]: https://github.com/OP-TEE/build/blob/master/hikey.mk#L11-L13
 [96Boards UART Adapter Board]: http://www.96boards.org/product/uarts

--- a/docs/juno.md
+++ b/docs/juno.md
@@ -134,4 +134,4 @@ NOR5LOAD: 00000000               ;Image Load Address
 NOR5ENTRY: 00000000              ;Image Entry Point
 ```
 
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md

--- a/docs/mtk8173.md
+++ b/docs/mtk8173.md
@@ -21,5 +21,5 @@ contains information about how to upgrade the firmware etc. There is also a
 link for how to run OP-TEE. We **don't** recommend that you follow that, since
 that guide is very old and has been superseded by this particular guide.
 
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md
 [MTK8173 Getting Started]: https://github.com/ibanezchen/linux-8173/wiki

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -46,4 +46,4 @@ $ mount_shared <mount_point>
 ```
 
 [bios]: https://github.com/linaro-swg/bios_qemu_tz_arm
-[README.md]: https://github.com/OP-TEE/build/README.md
+[README.md]: ../README.md


### PR DESCRIPTION
Use a relative path to README.md instead of a URL, so that the file for
the current HEAD is shown.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>