### PR TITLE
hikey: Update HiKey Debian for 2.3.0 release

### DIFF
--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -17,14 +17,14 @@ CFG_SW_CONSOLE_UART ?= 3
 # TODO: Figure out how to handle this in a better way, but we need a version
 # number with major and minor for the debian packages.
 #   <major version>.<minor version>-<package revision>
-OPTEE_PKG_VERSION ?= 2.0-1
+OPTEE_PKG_VERSION ?= 2.3-0
 
 # IP-address to the HiKey device
 IP ?= 127.0.0.1
 
 # URL to images
 SYSTEM_IMG_URL=https://builds.96boards.org/releases/reference-platform/debian/hikey/16.03/hikey-rootfs-debian-jessie-alip-20160301-68.emmc.img.gz
-BOOT_IMG_URL=https://builds.96boards.org/releases/reference-platform/debian/hikey/16.03/hikey-boot-linux-20160301-68.uefi.img.gz
+BOOT_IMG_URL=https://builds.96boards.org/releases/reference-platform/debian/hikey/16.06/hikey-boot-linux-20160629-120.uefi.img.gz
 NVME_IMG_URL=https://builds.96boards.org/releases/hikey/linaro/binaries/latest/nvme.img
 
 ################################################################################
@@ -151,7 +151,6 @@ edk2-clean: edk2-clean-common
 ################################################################################
 LINUX_DEFCONFIG_COMMON_ARCH ?= arm64
 LINUX_DEFCONFIG_COMMON_FILES ?= $(LINUX_PATH)/arch/arm64/configs/defconfig \
-				$(LINUX_PATH)/arch/arm64/configs/distro.config \
 				$(CURDIR)/kconfigs/hikey_debian.conf
 
 linux-defconfig: $(LINUX_PATH)/.config
@@ -358,10 +357,16 @@ endef
 .PHONY: recovery
 recovery:
 	@echo "Enter recovery mode to flash a new bootloader"
+	@echo
+	@echo "Make sure udev permissions are set appropriately:"
+	@echo "  # /etc/udev/rules.d/hikey.rules"
+	@echo '  SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", ATTRS{idProduct}=="d00d", MODE="0666"'
+	@echo '  SUBSYSTEM=="usb", ATTRS{idVendor}=="12d1", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"'
+	@echo
 	@echo "Jumper 1-2: Closed (Auto power up = Boot up when power is applied)"
 	@echo "       3-4: Closed (Boot Select = Recovery: program eMMC from USB OTG)"
 	$(call flash_help)
-	sudo python $(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/l-loader.bin
+	python $(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/l-loader.bin
 	@$(MAKE) --no-print flash FROM_RECOVERY=1
 
 .PHONY: flash


### PR DESCRIPTION
- Use a newer boot image (pre-built 16.06 UEFI image)
- Remove sudo requirement when using burn-boot
- Add udev rules help, similar to the hikey.mk file
- Step up OPTEE_PKG_VERSION to 2.3-0

Known issues:
- On HiKey 4G devices it seems like the partition table is to small to
  be able fit the newer 16.06 Debian root fs. It might be that we can
  tweak the partition table a bit, but for the moment we will keep using
  the 16.03 Debian root fs.

- When running this on the device
     $ dpkg --force-all -i /tmp/linux-image-*.deb
  there will be errors like this:
     blockdev: ioctl error on BLKROSET: Operation not permitted
  According to the comments in:
     https://github.com/OP-TEE/optee_os/issues/1234
  that message only shows up on the 16.03 root fs and it seems to only
  show up when running later kernel versions. However, if you reboot the
  device, everything is working, i.e, it will boot up your new kernel
  etc. We need to investige further to find the root cause for the error
  message and to implement a proper solution without error messages.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>