### PR TITLE
Fix for the website render

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -10,6 +10,7 @@ Frequently Asked Questions
 8.  [Trusted Applications](#8-trusted-applications)
 9.  [Testing](#9-testing)
 
+--------------
 
 1. Source code
 --------------


### PR DESCRIPTION
On https://www.op-tee.org/faq/ after 9, 10 comes. This is due to a know github bug. If we can add a line break, I assume this should fix the rendering issue on the website.