### PR TITLE
Fix for serverip issue

### DIFF
--- a/rpi3/firmware/uboot.env.txt
+++ b/rpi3/firmware/uboot.env.txt
@@ -25,7 +25,7 @@ kernel_addr_r=0x10000000
 # NFS/TFTP boot configuraton
 gatewayip=192.168.1.1
 netmask=255.255.255.0
-serverip=192.168.1.5
+tftpserverip=192.168.1.5
 nfspath=/opt/linaro/nfs
 
 # bootcmd & bootargs configuration
@@ -34,8 +34,8 @@ load_dtb=fatload mmc 0:1 ${fdt_addr_r} ${fdtfile}
 load_firmware=fatload mmc 0:1 ${atf_load_addr} ${atf_file}
 load_kernel=fatload mmc 0:1 ${kernel_addr_r} Image
 mmcboot=run load_kernel; run load_dtb; run load_firmware; run set_bootargs_tty set_bootargs_mmc set_common_args; run boot_it
-nfsboot=usb start; dhcp ${kernel_addr_r} ${serverip}:Image; dhcp ${fdt_addr_r} ${serverip}:${fdtfile}; dhcp ${atf_load_addr} ${serverip}:${atf_file}; run set_bootargs_tty set_bootargs_nfs set_common_args; run boot_it
+nfsboot=usb start; dhcp ${kernel_addr_r} ${tftpserverip}:Image; dhcp ${fdt_addr_r} ${tftpserverip}:${fdtfile}; dhcp ${atf_load_addr} ${tftpserverip}:${atf_file}; run set_bootargs_tty set_bootargs_nfs set_common_args; run boot_it
 set_bootargs_tty=setenv bootargs console=${ttyconsole},${baudrate}
-set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${serverip}:${nfspath},udp,vers=3 ip=dhcp
+set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${tftpserverip}:${nfspath},udp,vers=3 ip=dhcp
 set_bootargs_mmc=setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfs=ext4
 set_common_args=setenv bootargs ${bootargs} ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes smsc95xx.macaddr=${ethaddr} 'bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000'


### PR DESCRIPTION
U-boot dhcp/bootp client changes "serverip" variable value in case if it was specified in a dhcp/bootp server configuration. 
Renamed `serverip` var, which now is used for `nfsboot` target to avoid updating of this value by DHCP/BOOTP clients and just to use our pre-defined static value.

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`