### PR TITLE
Travis enablement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+# Travis configuration file for downloading and building OP-TEE according to the
+# instructions in build.git
+language: bash
+
+notifications:
+  email:
+    recipients:
+      - op-tee@linaro.org
+      - joakim.bech@linaro.org
+    on_success: change
+    on_failure: always
+
+dist: trusty
+sudo: required
+group: beta
+
+cache:
+  directories:
+    - $HOME/reference
+    - $HOME/.ccache
+
+git:
+  depth: 3
+
+after_script:
+  - ccache -s
+
+before_install:
+  - ccache -s
+  - sudo dpkg --add-architecture i386
+  - sudo apt-get update -qq
+  # Taken from README.md + device-tree-compiler
+  - sudo apt-get install -qq -y android-tools-adb android-tools-fastboot autoconf automake bc bison build-essential cscope curl device-tree-compiler flex ftp-upload gdisk libattr1-dev libc6:i386 libcap-dev libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make mtools netcat python-crypto python-serial python-wand unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
+
+install: true
+
+env:
+  - $REPO_PROJ=default
+  - $REPO_PROJ=fvp
+  - $REPO_PROJ=hikey
+  - $REPO_PROJ=juno
+  - $REPO_PROJ=mt8173-evb
+  - $REPO_PROJ=qemu_v8
+  - $REPO_PROJ=rpi3
+  #- $REPO_PROJ=dra7xx # Cannot build this since it requires TI_SECURE_DEV_PKG
+
+before_script:
+  - mkdir $HOME/bin
+  - cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo
+  - export PATH=$HOME/bin:$PATH
+  - cd $HOME/reference && git clone https://github.com/OP-TEE/build.git;
+  - cd $HOME/reference/build && make -f toolchain.mk toolchains -j3;
+  - cd $HOME/reference/toolchains && rm -f *.tar.gz && rm -rf $HOME/reference/build;
+
+script:
+  - mkdir -p $HOME/$REPO_PROJ
+  # Special case for FVP, since we check for the Foundation_Platformpkg folder
+  # in the makefile
+  - if [ $REPO_PROJ == "fvp" ]; then mkdir -p $HOME/$REPO_PROJ/Foundation_Platformpkg; fi
+  - cd $HOME/$REPO_PROJ && repo init -u https://github.com/OP-TEE/manifest.git -m $REPO_PROJ.xml </dev/null && repo sync -j2 --no-clone-bundle --no-tags --quiet
+  - cd $HOME/$REPO_PROJ && ln -s $HOME/reference/toolchains .
+  - cd $HOME/$REPO_PROJ/build && make all -j2

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -21,16 +21,26 @@ LEGACY_AARCH64_CROSS_COMPILE    ?= $(LEGACY_AARCH64_PATH)/bin/aarch64-linux-gnu-
 LEGACY_AARCH64_GCC_VERSION      ?= gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
 LEGACY_SRC_AARCH64_GCC          ?= http://releases.linaro.org/archive/14.08/components/toolchain/binaries/${LEGACY_AARCH64_GCC_VERSION}.tar.xz
 
-toolchains:
-	mkdir -p $(AARCH32_PATH)
-	curl -L $(SRC_AARCH32_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz
-	tar xf $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz -C $(AARCH32_PATH) --strip-components=1
+toolchains: aarch32 aarch64 aarch64-legacy
 
-	mkdir -p $(AARCH64_PATH)
-	curl -L $(SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz
-	tar xf $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz -C $(AARCH64_PATH) --strip-components=1
+aarch32:
+	if [ ! -d "$(AARCH32_PATH)" ]; then \
+		mkdir -p $(AARCH32_PATH); \
+		curl -L $(SRC_AARCH32_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz; \
+		tar xf $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz -C $(AARCH32_PATH) --strip-components=1; \
+	fi
 
-	mkdir -p $(LEGACY_AARCH64_PATH)
-	curl -L $(LEGACY_SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz
-	tar xf $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz -C $(LEGACY_AARCH64_PATH) --strip-components=1
+aarch64:
+	if [ ! -d "$(AARCH64_PATH)" ]; then \
+		mkdir -p $(AARCH64_PATH); \
+		curl -L $(SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz; \
+		tar xf $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz -C $(AARCH64_PATH) --strip-components=1; \
+	fi
+
+aarch64-legacy:
+	if [ ! -d "$(LEGACY_AARCH64_PATH)" ]; then \
+		mkdir -p $(LEGACY_AARCH64_PATH); \
+		curl -L $(LEGACY_SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz; \
+		tar xf $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz -C $(LEGACY_AARCH64_PATH) --strip-components=1; \
+	fi
 

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -1,7 +1,7 @@
 ################################################################################
 # Toolchains
 ################################################################################
-ROOT					?= $(CURDIR)/..
+ROOT				?= $(CURDIR)/..
 TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
@@ -21,26 +21,31 @@ LEGACY_AARCH64_CROSS_COMPILE    ?= $(LEGACY_AARCH64_PATH)/bin/aarch64-linux-gnu-
 LEGACY_AARCH64_GCC_VERSION      ?= gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
 LEGACY_SRC_AARCH64_GCC          ?= http://releases.linaro.org/archive/14.08/components/toolchain/binaries/${LEGACY_AARCH64_GCC_VERSION}.tar.xz
 
+# Download toolchain macro for saving some repetition
+# $(1) is $AARCH.._PATH		: i.e., path to the destination
+# $(2) is $SRC_AARCH.._GCC	: is the downloaded tar.gz file
+# $(3) is $.._GCC_VERSION	: the name of the file to download
+define dltc
+	@if [ ! -d "$(1)" ]; then \
+		mkdir -p $(1); \
+		echo "Downloading $(3) ..."; \
+		curl -s -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz; \
+		tar xf $(TOOLCHAIN_ROOT)/$(3).tar.xz -C $(1) --strip-components=1; \
+	fi
+endef
+
+.PHONY: toolchains
 toolchains: aarch32 aarch64 aarch64-legacy
 
+.PHONY: aarch32
 aarch32:
-	if [ ! -d "$(AARCH32_PATH)" ]; then \
-		mkdir -p $(AARCH32_PATH); \
-		curl -L $(SRC_AARCH32_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz; \
-		tar xf $(TOOLCHAIN_ROOT)/$(AARCH32_GCC_VERSION).tar.xz -C $(AARCH32_PATH) --strip-components=1; \
-	fi
+	$(call dltc,$(AARCH32_PATH),$(SRC_AARCH32_GCC),$(AARCH32_GCC_VERSION))
 
+.PHONY: aarch64
 aarch64:
-	if [ ! -d "$(AARCH64_PATH)" ]; then \
-		mkdir -p $(AARCH64_PATH); \
-		curl -L $(SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz; \
-		tar xf $(TOOLCHAIN_ROOT)/$(AARCH64_GCC_VERSION).tar.xz -C $(AARCH64_PATH) --strip-components=1; \
-	fi
+	$(call dltc,$(AARCH64_PATH),$(SRC_AARCH64_GCC),$(AARCH64_GCC_VERSION))
 
+.PHONY: aarch64-legacy
 aarch64-legacy:
-	if [ ! -d "$(LEGACY_AARCH64_PATH)" ]; then \
-		mkdir -p $(LEGACY_AARCH64_PATH); \
-		curl -L $(LEGACY_SRC_AARCH64_GCC) -o $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz; \
-		tar xf $(TOOLCHAIN_ROOT)/$(LEGACY_AARCH64_GCC_VERSION).tar.xz -C $(LEGACY_AARCH64_PATH) --strip-components=1; \
-	fi
+	$(call dltc,$(LEGACY_AARCH64_PATH),$(LEGACY_SRC_AARCH64_GCC),$(LEGACY_AARCH64_GCC_VERSION))
 


### PR DESCRIPTION
In the quest for updating to GCC6.x I wanted to investigate the ability to automate building full OP-TEE repo configurations (only build, no testing). After lots of trail and error and reading I think I've manged to come up with something that works pretty good using Travis. An example of a complete and successful build looks like this (and some of you will probably get an email when Travis has completed the build for this PR):
https://travis-ci.org/jbech-linaro/build/builds/195839345

Individual build time for each project is ~40 minutes and in total it runs for 1h 20min. I have played with enabling caches, but I don't think I've got it working as it should. Because 40 minutes is quite much time compared to local (cached) setups on my own computer. Unfortunately it's a guessing game, since there isn't that much documentation about it and you cannot (what I know) print folders etc so "see" what is in the cache. I've even played with using a repo reference, but no real success. Probably worth investigate this further when we have the base functionality in place.

There are various ways to enable when Travis should trigger builds. Pushing to branches, when creating pull request (like on optee_os) and they now also have cron job in Beta. I think I'd like to start with running a cron job on daily basis. We don't have that much activity in build.git, so by running as cron job, we will implicitly make builds containing changes in our other gits to and therefore we would know if those break the repo setups. We can of course also enable it for pull request if we think we need that and again, the low activity in build.git makes me think that it indeed would be OK to enable for pull requests.

When doing this I've also made two changes to the toolchain.mk. One patch enables parallel downloads of toolchains and prevent from re-download if already downloaded. The second patch simplifies the download a bit by wrapping it in a macro. I'm fully aware that an interrupted download will foobar this since folders will be there, but not the entire content. The likelihood that it happens is low and I'm willing to take the risk/trade-off there. Likewise I haven't bother doing any toolchains-clean target, since ... the rest of you seems to wanna do that in a more complicated way than I would have done :) So, feel free to send patches doing a nice cleanup later on.

When this has been merged, it should be easier to check the **builds** when enabling GCC6.x.

// Joakim
(I think we can update optee_os/.travis.xml with some **env** also, to simplify that file a bit also).