### PR TITLE
Final piece of the toolchain upgrade (gcc6.x)

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -65,9 +65,6 @@ the using the ARM toolchain. Please install the [OP-TEE pre-requisties] and this
 time try to ensure that you are using GCC for ARM (for more information, please
 see [Issue#846]).
 
-### I can't get OP-TEE to build using GCC 6.x?
-GCC 6.x isn't currently supported, please see [Issue#1200] for more information.
-
 ### I found this build.git, what is that?
 That git is used in conjunction with the [OP-TEE repo setups]. It contains
 helper makefiles that makes it easy to get OP-TEE up and running on the setups
@@ -440,4 +437,3 @@ using [Travis for OP-TEE].
 [Issue#1183]: https://github.com/OP-TEE/optee_os/issues/1183
 [Issue#1194]: https://github.com/OP-TEE/optee_os/issues/1194
 [Issue#1195]: https://github.com/OP-TEE/optee_os/issues/1195
-[Issue#1200]: https://github.com/OP-TEE/optee_os/issues/1200

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -6,13 +6,13 @@ TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
 AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
-AARCH32_GCC_VERSION 		?= gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabihf
-SRC_AARCH32_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/5.3-2016.05/arm-linux-gnueabihf/${AARCH32_GCC_VERSION}.tar.xz
+AARCH32_GCC_VERSION 		?= gcc-linaro-6.2.1-2016.11-x86_64_arm-linux-gnueabihf
+SRC_AARCH32_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/6.2-2016.11/arm-linux-gnueabihf/${AARCH32_GCC_VERSION}.tar.xz
 
 AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
 AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
-AARCH64_GCC_VERSION 		?= gcc-linaro-5.3.1-2016.05-x86_64_aarch64-linux-gnu
-SRC_AARCH64_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/5.3-2016.05/aarch64-linux-gnu/${AARCH64_GCC_VERSION}.tar.xz
+AARCH64_GCC_VERSION 		?= gcc-linaro-6.2.1-2016.11-x86_64_aarch64-linux-gnu
+SRC_AARCH64_GCC 		?= http://releases.linaro.org/components/toolchain/binaries/6.2-2016.11/aarch64-linux-gnu/${AARCH64_GCC_VERSION}.tar.xz
 
 # Due to relocation error on the 96board edk forest, let's keep the old
 # toolchain for a while.


### PR DESCRIPTION
This is the patch that step up default toolchain in build.git to GCC6.x. Note that I had to add a dummy patch for Travis so that it was actually checking out GCC6.x when running the Travis job. That should not be included when merging this. I'll remove that when adding R-B tags etc. However, my push looked good on my local branch, see -> https://travis-ci.org/jbech-linaro/build/builds/199189080                                                   
                                                                                                                
So, hopefully this should be it.