### PR TITLE
qemu-check.exp: do not start tee-supplicant

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -56,14 +56,11 @@ expect {
 }
 send -- "\r"
 expect "root@Vexpress:/ "
-info " done, guest is booted.\nLoading OP-TEE driver and tee-supplicant..."
+info " done, guest is booted.\n"
 # Toolchain libraries might be here or there
 send -- "export LD_LIBRARY_PATH=/lib:/lib/arm-linux-gnueabihf\r"
 expect "root@Vexpress:/ "
-send -- "tee-supplicant&\r"
-expect "root@Vexpress:/ "
-sleep 1
-info " done.\nRunning: $cmd...\n"
+info "Running: $cmd...\n"
 send -- "$cmd\r"
 set casenum "none"
 expect {


### PR DESCRIPTION
Since commit 1333db4d959b ("rootfs: start tee-supplicant on boot"),
there is no need to start tee-supplicant from qemu-check.exp.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>