### PR TITLE
fvp: emulate ARM-v8.0

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -159,6 +159,7 @@ run-only:
 	@ln -sf $(LINUX_PATH)/arch/arm64/boot/dts/arm/foundation-v8.dtb $(FOUNDATION_PATH)/fdt.dtb
 	@cd $(FOUNDATION_PATH); \
 	$(FOUNDATION_PATH)/models/Linux64_GCC-4.7/Foundation_Platform \
+	--arm-v8.0 \
 	--cores=4 \
 	--secure-memory \
 	--visualization \


### PR DESCRIPTION
Adds switch --arm-v8.0 to FVP command line to enable ARM v8.0
architecture only.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>