### PR TITLE
doc: minor: add dtc to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ target you will use in the end.
 
 ```bash
 $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
-	automake bc bison build-essential cscope curl flex ftp-upload gdisk \
-	libattr1-dev libc6:i386 libcap-dev libfdt-dev libftdi-dev \
+	automake bc bison build-essential cscope curl device-tree-compiler flex \
+	ftp-upload gdisk libattr1-dev libc6:i386 libcap-dev libfdt-dev libftdi-dev \
 	libglib2.0-dev libhidapi-dev libncurses5-dev libpixman-1-dev \
 	libssl-dev libstdc++6:i386 libtool libz1:i386 make mtools netcat \
 	python-crypto python-serial python-wand unzip uuid-dev xdg-utils \


### PR DESCRIPTION
Device tree compiler is also needed for U-Boot compilation for TI platforms

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`