### PR TITLE
rpi3: minor: add output to both monitor and UART

### DIFF
--- a/rpi3/firmware/uboot.env.txt
+++ b/rpi3/firmware/uboot.env.txt
@@ -10,7 +10,8 @@ smp=on
 
 # Console config
 baudrate=115200
-ttyconsole=ttyS0
+sttyconsole=ttyS0
+ttyconsole=tty0
 
 # Kernel/firmware/dtb filenames & load addresses
 atf_load_addr=0x08400000
@@ -29,13 +30,14 @@ tftpserverip=192.168.1.5
 nfspath=/opt/linaro/nfs
 
 # bootcmd & bootargs configuration
+preboot=usb start
 bootcmd=run mmcboot
 load_dtb=fatload mmc 0:1 ${fdt_addr_r} ${fdtfile}
 load_firmware=fatload mmc 0:1 ${atf_load_addr} ${atf_file}
 load_kernel=fatload mmc 0:1 ${kernel_addr_r} Image
 mmcboot=run load_kernel; run load_dtb; run load_firmware; run set_bootargs_tty set_bootargs_mmc set_common_args; run boot_it
 nfsboot=usb start; dhcp ${kernel_addr_r} ${tftpserverip}:Image; dhcp ${fdt_addr_r} ${tftpserverip}:${fdtfile}; dhcp ${atf_load_addr} ${tftpserverip}:${atf_file}; run set_bootargs_tty set_bootargs_nfs set_common_args; run boot_it
-set_bootargs_tty=setenv bootargs console=${ttyconsole},${baudrate}
+set_bootargs_tty=setenv bootargs console=${ttyconsole} console=${sttyconsole},${baudrate}
 set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${tftpserverip}:${nfspath},udp,vers=3 ip=dhcp
 set_bootargs_mmc=setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfs=ext4
-set_common_args=setenv bootargs ${bootargs} ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes smsc95xx.macaddr=${ethaddr} 'bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000'
+set_common_args=setenv bootargs ${bootargs} smsc95xx.macaddr=${ethaddr} 'ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000'


### PR DESCRIPTION
Add support of kernel output both to connected monitor and UART
Add "usb start" at pre-boot stage to be able to use a keyboard in U-Boot

Fixes: https://github.com/OP-TEE/optee_os/issues/1367
https://github.com/OP-TEE/build/issues/131

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`