### PR TITLE
ti: Remove uEnv.txt for TI builds

### DIFF
--- a/docs/ti.md
+++ b/docs/ti.md
@@ -50,7 +50,6 @@ Add the bootloader to the 'boot' partition
 # cd <SD card boot partition>
 # cp <repo directory>/u-boot/u-boot-spl_HS_MLO MLO
 # cp <repo directory>/u-boot/u-boot_HS.img u-boot.img
-# cp <repo directory>/build/ti/uEnv.txt uEnv.txt
 ```
 
 [README.md]: ../README.md

--- a/ti/ti-common.mk
+++ b/ti/ti-common.mk
@@ -122,7 +122,6 @@ filelist-tee: filelist-tee-common u-boot build-fit
 	@echo "dir /boot 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/MLO $(UBOOT_SPL) 644 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/u-boot.img $(UBOOT_IMG) 644 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/uEnv.txt $(UBOOT_ENV) 644 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/fitImage $(STAGING_AREA)/fitImage 644 0 0" >> $(GEN_ROOTFS_FILELIST)
 
 update_rootfs: update_rootfs-common

--- a/ti/uEnv.txt
+++ b/ti/uEnv.txt
@@ -1,1 +1,0 @@
-loadfit=run args_mmc; bootm ${loadaddr}#${fdtfile};


### PR DESCRIPTION
uEnv.txt was needed due to a bug in the default U-Boot environment,
this has been fixed upstream and the TI repo used in this build.
Remove this file.

Signed-off-by: Andrew F. Davis <afd@ti.com>