### PR TITLE
README: Remove `run` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ symlink the `Makefile` to the correct device specific makefile, that means that
 you simply start the build by running:
 
 ```bash
-$ make all run
+$ make all
 ```
 This step will also take some time, but you can speed up subsequent builds by
 enabling [ccache] (again see Tips and Tricks).

--- a/docs/mtk8173.md
+++ b/docs/mtk8173.md
@@ -10,9 +10,9 @@ The instructions here will tell how to run OP-TEE using the MTK1873 device.
 
 # 2. Regular build
 Start by following the "Get and build the solution" in the [README.md] file.
-When everything has been built and it is booting up, it will stop in fastboot
-waiting for the binaries. At that point, press reset button and the flashing
-procedure should begin.
+Continue with `make run`. When everything has been built and it is booting up,
+it will stop in fastboot waiting for the binaries. At that point, press reset
+button and the flashing procedure should begin.
 
 # 3. External guide
 A MediaTek engineer (Howard Chen) has put detailed descriptions on how to


### PR DESCRIPTION
Only QEMU, FVP and MTK8173 have a `run` target but all *.md files
refer to README Section 7.5 which calls for `make all run`. Remove
this target and add it to mtk8173.md instead. qemu.md and fvp.md
already mentions the run target so don't need to be added again.

Fixes: https://github.com/OP-TEE/build/issues/146
Signed-off-by: Victor Chong <victor.chong@linaro.org>