### PR TITLE
Use config.txt to enable JTAG instead of U-Boot

### DIFF
--- a/docs/rpi3.md
+++ b/docs/rpi3.md
@@ -222,7 +222,7 @@ $ cd /home/jbech/devel/optee_projects/rpi3/boot/
 # clean previous uboot.env
 $ make u-boot-env-clean
 # generate new
-$ make u-boot-jtag-bin
+$ make u-boot-bin
 ```
 Then you need to copy your newly generated `uboot.env`(it's stored in `../out/uboot.env`)
 to the BOOT partition of your SD card.
@@ -292,19 +292,20 @@ need to reboot the RPi after a rebuild.
 # 6. OpenOCD and JTAG
 First a word of warning here, even though this seems to be working quite good as
 of now, it should be well understood that this is based on incomplete and out of
-tree patches. So what are the major changes that enables this? First [OpenOCD]
-currently doesn't contain ARMv8-A / AArch64 support in the upstream tree. A
-couple of different people have put something together that gets the job done.
-But to get in a shape for upstream, there is still quite a lot left to do. The
-other change needed is in U-Boot, that is where we configure the [RPi3 GPIO
-pins] so that they will talk JTAG. The pin configuration and the wiring for the
-cable looks like this:
+tree patches. Indeed, [OpenOCD] currently doesn't contain ARMv8-A / AArch64
+support in the upstream tree. A couple of different people have put something
+together that gets the job done. But to get in a shape for upstream, there is
+still quite a lot left to do.
+
+To enable JTAG you need to uncomment the line: `enable_jtag_gpio=1` in
+`rpi3/firmware/config.txt`.
+The pin configuration and the wiring for the cable looks like this:
 
 |JTAG pin|Signal|GPIO   |Mode |Header pin|
 |--------|------|-------|-----|----------|
 | 1      |3v3   |N/A    |N/A  | 1        |
 | 3      |nTRST |GPIO22 |ALT4 | 15       |
-| 5      |TDI   |GPIO4  |ALT5 | 7        |
+| 5      |TDI   |GPIO26 |ALT4 | 37       |
 | 7      |TMS   |GPIO27 |ALT4 | 13       |
 | 9      |TCK   |GPIO25 |ALT4 | 22       |
 | 11     |RTCK  |GPIO23 |ALT4 | 16       |

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -38,7 +38,7 @@ ARM_TF_BOOT             ?= $(ARM_TF_OUT)/optee.bin
 
 U-BOOT_PATH		?= $(ROOT)/u-boot
 U-BOOT_BIN		?= $(U-BOOT_PATH)/u-boot.bin
-U-BOOT_JTAG_BIN		?= $(U-BOOT_PATH)/u-boot-jtag.bin
+U-BOOT_RPI_BIN		?= $(U-BOOT_PATH)/u-boot-rpi.bin
 
 RPI3_FIRMWARE_PATH		?= $(BUILD_PATH)/rpi3/firmware
 RPI3_HEAD_BIN			?= $(ROOT)/out/head.bin
@@ -57,9 +57,9 @@ MODULE_OUTPUT		?= $(ROOT)/module_output
 ################################################################################
 # Targets
 ################################################################################
-all: rpi3-firmware arm-tf optee-os optee-client xtest u-boot u-boot-jtag-bin\
+all: rpi3-firmware arm-tf optee-os optee-client xtest u-boot u-boot-rpi-bin\
 	linux update_rootfs
-clean: arm-tf-clean busybox-clean u-boot-clean u-boot-jtag-bin-clean \
+clean: arm-tf-clean busybox-clean u-boot-clean u-boot-rpi-bin-clean \
 	optee-os-clean optee-client-clean rpi3-firmware-clean head-bin-clean
 
 -include toolchain.mk
@@ -107,11 +107,11 @@ u-boot: $(RPI3_HEAD_BIN)
 u-boot-clean:
 	$(U-BOOT_EXPORTS) $(MAKE) -C $(U-BOOT_PATH) clean
 
-u-boot-jtag-bin: $(RPI3_UBOOT_ENV) u-boot
-	cd $(U-BOOT_PATH) && cat $(RPI3_HEAD_BIN) $(U-BOOT_BIN) > $(U-BOOT_JTAG_BIN)
+u-boot-rpi-bin: $(RPI3_UBOOT_ENV) u-boot
+	cd $(U-BOOT_PATH) && cat $(RPI3_HEAD_BIN) $(U-BOOT_BIN) > $(U-BOOT_RPI_BIN)
 
-u-boot-jtag-bin-clean:
-	rm -f $(U-BOOT_JTAG_BIN)
+u-boot-rpi-bin-clean:
+	rm -f $(U-BOOT_RPI_BIN)
 
 $(RPI3_HEAD_BIN): $(RPI3_FIRMWARE_PATH)/head.S
 	mkdir -p $(ROOT)/out/
@@ -250,7 +250,7 @@ filelist-tee: filelist-tee-common
 	@echo "file /boot/Image $(LINUX_IMAGE) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/optee.bin $(ARM_TF_BOOT) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/uboot.env $(RPI3_UBOOT_ENV) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/u-boot-jtag.bin $(U-BOOT_JTAG_BIN) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
+	@echo "file /boot/u-boot-rpi.bin $(U-BOOT_RPI_BIN) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
 	@cd $(MODULE_OUTPUT) && find ! -path . -type d | sed 's/\.\(.*\)/dir \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
 	@cd $(MODULE_OUTPUT) && find -type f | sed "s|\.\(.*\)|file \1 $(MODULE_OUTPUT)\1 755 0 0|g" >> $(GEN_ROOTFS_FILELIST)
 	@echo "file /boot/bootcode.bin $(RPI3_STOCK_FW_PATH)/boot/bootcode.bin 755 0 0" >> $(GEN_ROOTFS_FILELIST)

--- a/rpi3/firmware/config.txt
+++ b/rpi3/firmware/config.txt
@@ -2,7 +2,8 @@ enable_uart=1
 arm_control=0x200
 kernel_old=1
 
-kernel=u-boot-jtag.bin
+kernel=u-boot-rpi.bin
+enable_jtag_gpio=1
 
 disable_commandline_tags=1
 


### PR DESCRIPTION
See the Issue I filed in optee_os: https://github.com/OP-TEE/optee_os/issues/1634

Any merge should be synchronized with the PR I opened in linaro-swg/u-boot: https://github.com/linaro-swg/u-boot/pull/1