### PR TITLE
qemu_v8: recent QEMU requires libfdt 1.4.2 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ script:
   # in the makefile.
   - if [ $REPO_PROJ == "fvp" ]; then mkdir -p $HOME/$REPO_PROJ/Foundation_Platformpkg; fi
   - cd $HOME/$REPO_PROJ && repo init -u https://github.com/OP-TEE/manifest.git -m $REPO_PROJ.xml </dev/null && repo sync -j2 --no-clone-bundle --no-tags --quiet
-  # Fetch a local copy of dtc+libfdt to avoid issues with a possibly outdated libfdt-dev
-  - if [ $REPO_PROJ == "qemu_v8" ]; then cd $HOME/$REPO_PROJ/qemu && git submodule update --init dtc; fi
   # Here we are using Travis environment variables to select the correct branch
   # based on either a pull request or a normal push.
   - |

--- a/qemu.mk
+++ b/qemu.mk
@@ -53,7 +53,9 @@ bios-qemu-clean:
 	$(call bios-qemu-common) clean
 
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu\
+	cd $(QEMU_PATH); \
+		git submodule update --init dtc && \
+		./configure --target-list=arm-softmmu \
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 	$(MAKE) -C $(QEMU_PATH)
 

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -65,7 +65,11 @@ arm-tf-clean:
 # QEMU
 ################################################################################
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu\
+	cd $(QEMU_PATH); \
+		dpkg --compare-versions 1.4.2 le \
+		    `dpkg-query --showformat='$${Version}' --show libfdt-dev` || \
+		    git submodule update --init dtc && \
+		./configure --target-list=aarch64-softmmu \
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 	$(MAKE) -C $(QEMU_PATH)
 

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -66,9 +66,7 @@ arm-tf-clean:
 ################################################################################
 qemu:
 	cd $(QEMU_PATH); \
-		dpkg --compare-versions 1.4.2 le \
-		    `dpkg-query --showformat='$${Version}' --show libfdt-dev` || \
-		    git submodule update --init dtc && \
+		git submodule update --init dtc && \
 		./configure --target-list=aarch64-softmmu \
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 	$(MAKE) -C $(QEMU_PATH)


### PR DESCRIPTION
Ubuntu 1.4.04 LTS, 16.04 LTS and even 17.04 provide the libfdt in
version 1.4.0. This version is too old for QEMU that requires libfdt
in version 1.4.2 or higher.

This change insures DTC package is locally clone so that QEMU builds
over it rather than using the libfdt support and tools from the system.

Suggested-by: Joakim Bech <joakim.bech@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>