### PR TITLE
common.mk: allow user to override launch-terminal in make run

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -228,6 +228,12 @@ define run-help
 	@echo
 endef
 
+ifneq ("", $(LAUNCH_TERMINAL))
+define launch-terminal
+	@nc -z  127.0.0.1 $(1) || \
+		$(LAUNCH_TERMINAL) $(SOC_TERM_PATH)/soc_term $(1) &
+endef
+else
 gnome-terminal := $(shell command -v gnome-terminal 2>/dev/null)
 xterm := $(shell command -v xterm 2>/dev/null)
 ifdef gnome-terminal
@@ -245,6 +251,7 @@ define launch-terminal
 endef
 else
 check-terminal := @echo "Error: could not find gnome-terminal nor xterm" ; false
+endif
 endif
 endif
 


### PR DESCRIPTION
Currently the code is hard coded to launch netcat via either xterm or
gnome-terminal. This is a little inflexible for people who spend a lot
of time in terminals. With the following you can now do:

  env QEMU_PATH=~/lsrc/qemu/qemu.git/ \
      LAUNCH_TERMINAL="tmux split-window" \
      make -j run

To bring your nc instances up in new tmux windows. The one downside is
titles aren't set as that wouldn't be maximally flexible for whatever
your launch command is.

Signed-off-by: Alex Bennée <alex.bennee@linaro.org>