### PR TITLE
Travis: Add -p when create the bin folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
   #- $REPO_PROJ=dra7xx # Cannot build this since it requires TI_SECURE_DEV_PKG
 
 before_script:
-  - mkdir $HOME/bin
+  - mkdir -p $HOME/bin
   - cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo
   - export PATH=$HOME/bin:$PATH
   - mkdir -p $HOME/$REPO_PROJ


### PR DESCRIPTION
It seems like Travis have changed the images in such a way that there is
already a $HOME/bin folder, therefore we must use the '-p', when
creating the folder in our .travis.xml file.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>