### PR TITLE
common.mk: use CROSS_COMPILE for optee_benchmark

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -339,7 +339,7 @@ helloworld-clean-common:
 ################################################################################
 # benchmark_app
 ################################################################################
-BENCHMARK_APP_COMMON_FLAGS ?= HOST_CROSS_COMPILE=$(CROSS_COMPILE_NS_USER) \
+BENCHMARK_APP_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER) \
 	TEEC_EXPORT=$(OPTEE_CLIENT_EXPORT) \
 	TEEC_INTERNAL_INCLUDES=$(OPTEE_CLIENT_PATH)/libteec
 


### PR DESCRIPTION
Related to https://github.com/linaro-swg/optee_benchmark/pull/2

`optee_benchmark` was previously using both `CROSS_COMPILE` and `HOST_CROSS_COMPILE` in its Makefile, causing build errors.