### PR TITLE
common.mk: fix invalid empty test on $(LAUNCH_TERMINAL)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -243,7 +243,7 @@ define run-help
 	@echo
 endef
 
-ifneq ("", $(LAUNCH_TERMINAL))
+ifneq (, $(LAUNCH_TERMINAL))
 define launch-terminal
 	@nc -z  127.0.0.1 $(1) || \
 		$(LAUNCH_TERMINAL) $(SOC_TERM_PATH)/soc_term $(1) &


### PR DESCRIPTION
When LAUNCH_TERMINAL is not set, `make run` hangs with the following
messages:

 soc_term: save_current_termios: tcgetattr: Inappropriate ioctl for device
 soc_term: save_current_termios: tcgetattr: Inappropriate ioctl for device

The reason is an invalid test in common.mk.

Fixes: 07580605eabd ("common.mk: allow user to override launch-terminal in make run")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>