### PR TITLE
examples: use optee_examples instead of hello_world

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -27,9 +27,9 @@ endif
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf edk2 linux optee-os optee-client xtest helloworld
+all: arm-tf edk2 linux optee-os optee-client xtest optee-examples
 clean: arm-tf-clean busybox-clean edk2-clean optee-os-clean \
-	optee-client-clean
+	optee-client-clean optee-examples-clean
 
 
 -include toolchain.mk
@@ -131,11 +131,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # Root FS

--- a/hikey.mk
+++ b/hikey.mk
@@ -60,11 +60,14 @@ PATCHES_PATH			?=$(ROOT)/patches_hikey
 ################################################################################
 # Targets
 ################################################################################
-all: prepare arm-tf boot-img lloader nvme strace
+all: prepare arm-tf boot-img lloader nvme strace optee-examples
 
-clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean helloworld-clean strace-clean update_rootfs-clean boot-img-clean lloader-clean grub-clean
+clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean \
+		optee-client-clean xtest-clean optee-examples-clean strace-clean \
+		update_rootfs-clean boot-img-clean lloader-clean grub-clean
 
-cleaner: clean prepare-cleaner busybox-cleaner linux-cleaner strace-cleaner nvme-cleaner grub-cleaner
+cleaner: clean prepare-cleaner busybox-cleaner linux-cleaner strace-cleaner \
+		nvme-cleaner grub-cleaner
 
 -include toolchain.mk
 
@@ -216,11 +219,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # strace

--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -88,11 +88,14 @@ DEBPKG_CONTROL_PATH		?= $(DEBPKG_PATH)/DEBIAN
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf linux boot-img lloader system-img nvme deb
+all: arm-tf linux boot-img lloader system-img nvme deb optee-examples
 
-clean: arm-tf-clean edk2-clean linux-clean optee-os-clean optee-client-clean xtest-clean helloworld-clean boot-img-clean lloader-clean grub-clean
+clean: arm-tf-clean edk2-clean linux-clean optee-os-clean optee-client-clean \
+		xtest-clean boot-img-clean lloader-clean grub-clean \
+		optee-examples-clean
 
-cleaner: clean prepare-cleaner linux-cleaner nvme-cleaner system-img-cleaner grub-cleaner
+cleaner: clean prepare-cleaner linux-cleaner nvme-cleaner \
+			system-img-cleaner grub-cleaner
 
 -include toolchain.mk
 
@@ -227,11 +230,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # grub
@@ -353,7 +356,7 @@ Architecture: arm64
 Depends:
 Maintainer: Joakim Bech <joakim.bech@linaro.org>
 Description: OP-TEE client binaries, test program and Trusted Applications
- Package contains tee-supplicant, libtee.so, xtest, hello_world and a set of
+ Package contains tee-supplicant, libtee.so, xtest, optee-examples and a set of
  Trusted Applications.
  NOTE! This package should only be used for testing and development.
 endef
@@ -361,19 +364,20 @@ endef
 export CONTROL_TEXT
 
 .PHONY: deb
-deb: prepare xtest helloworld optee-client
+deb: prepare xtest optee-examples optee-client
 	@mkdir -p $(DEBPKG_BIN_PATH) && cd $(DEBPKG_BIN_PATH) && \
 		cp -f $(OPTEE_CLIENT_EXPORT)/bin/tee-supplicant . && \
-		cp -f $(OPTEE_TEST_OUT_PATH)/xtest/xtest . && \
-		cp -f $(HELLOWORLD_PATH)/host/hello_world .
-
+		cp -f $(OPTEE_TEST_OUT_PATH)/xtest/xtest .
+	@if [ -e $(OPTEE_EXAMPLES_PATH)/out/ca ]; then \
+		for example in $(OPTEE_EXAMPLES_PATH)/out/ca/*; do \
+			cp -f $$example .; \
+		done; \
+	fi
 	@mkdir -p $(DEBPKG_LIB_PATH) && cd $(DEBPKG_LIB_PATH) && \
 		cp $(OPTEE_CLIENT_EXPORT)/lib/libtee* .
-
 	@mkdir -p $(DEBPKG_TA_PATH) && cd $(DEBPKG_TA_PATH) && \
 		cp $(HELLOWORLD_PATH)/ta/*.ta . && \
 		find $(OPTEE_TEST_OUT_PATH)/ta -name "*.ta" -exec cp {} . \;
-
 	@mkdir -p $(DEBPKG_CONTROL_PATH)
 	@echo "$$CONTROL_TEXT" > $(DEBPKG_CONTROL_PATH)/control
 	@cd $(OUT_PATH) && dpkg-deb --build optee_$(OPTEE_PKG_VERSION)

--- a/juno.mk
+++ b/juno.mk
@@ -23,9 +23,10 @@ U-BOOT_BIN		?= $(U-BOOT_PATH)/u-boot.bin
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf u-boot linux optee-os optee-client xtest helloworld update_rootfs
+all: arm-tf u-boot linux optee-os optee-client xtest optee-examples \
+	update_rootfs
 clean: arm-tf-clean busybox-clean u-boot-clean optee-os-clean \
-	optee-client-clean
+	optee-client-clean optee-examples-clean
 
 
 -include toolchain.mk
@@ -129,11 +130,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # Root FS

--- a/mediatek.mk
+++ b/mediatek.mk
@@ -21,10 +21,9 @@ ARM_TF_BIN			?= $(ARM_TF_PATH)/build/mt8173/debug/bl31.bin
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf linux optee-os optee-client xtest helloworld
+all: arm-tf linux optee-os optee-client xtest optee-examples
 clean: arm-tf-clean linux-clean busybox-clean optee-os-clean \
-	optee-client-clean
-
+	optee-client-clean optee-examples-clean
 
 -include toolchain.mk
 
@@ -104,10 +103,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
-helloworld-clean: helloworld-clean-common
+optee-examples: optee-examples-common
+
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # Root FS

--- a/qemu.mk
+++ b/qemu.mk
@@ -27,9 +27,10 @@ ifeq ($(CFG_TEE_BENCHMARK),y)
 all: benchmark-app
 clean: benchmark-app-clean
 endif
-all: bios-qemu qemu soc-term
+all: bios-qemu qemu soc-term optee-examples
 clean: bios-qemu-clean busybox-clean linux-clean optee-os-clean \
-	optee-client-clean qemu-clean soc-term-clean check-clean
+	optee-client-clean qemu-clean soc-term-clean check-clean \
+	optee-examples-clean
 
 -include toolchain.mk
 
@@ -128,11 +129,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # benchmark

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -32,10 +32,10 @@ ifeq ($(CFG_TEE_BENCHMARK),y)
 all: benchmark-app
 clean: benchmark-app-clean
 endif
-all: arm-tf edk2 qemu soc-term linux strace update_rootfs
+all: arm-tf edk2 qemu soc-term linux strace update_rootfs optee-examples
 clean: arm-tf-clean busybox-clean edk2-clean linux-clean \
 	optee-os-clean optee-client-clean qemu-clean \
-	soc-term-clean check-clean strace-clean
+	soc-term-clean check-clean strace-clean optee-examples-clean
 
 -include toolchain.mk
 
@@ -164,11 +164,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # strace

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -61,10 +61,11 @@ ifeq ($(CFG_TEE_BENCHMARK),y)
 all: benchmark-app
 clean: benchmark-app-clean
 endif
-all: rpi3-firmware arm-tf optee-os optee-client xtest u-boot u-boot-rpi-bin\
-	linux update_rootfs
-clean: arm-tf-clean busybox-clean u-boot-clean u-boot-rpi-bin-clean \
-	optee-os-clean optee-client-clean rpi3-firmware-clean head-bin-clean
+all: rpi3-firmware arm-tf optee-os optee-client xtest u-boot u-boot-jtag-bin\
+	linux update_rootfs optee-examples
+clean: arm-tf-clean busybox-clean u-boot-clean u-boot-jtag-bin-clean \
+	optee-os-clean optee-client-clean rpi3-firmware-clean head-bin-clean \
+	optee-examples-clean
 
 -include toolchain.mk
 
@@ -235,11 +236,11 @@ xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
 ################################################################################
-# hello_world
+# Sample applications / optee_examples
 ################################################################################
-helloworld: helloworld-common
+optee-examples: optee-examples-common
 
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ################################################################################
 # benchmark

--- a/ti/ti-common.mk
+++ b/ti/ti-common.mk
@@ -3,8 +3,10 @@
 ###############################################################################
 .PHONY: all clean cleaner prepare
 
-all: u-boot linux optee-os optee-client xtest helloworld build-fit update_rootfs
-clean: linux-clean busybox-clean u-boot-clean optee-os-clean optee-client-clean build-fit-clean
+all: u-boot linux optee-os optee-client xtest build-fit \
+	update_rootfs optee-examples
+clean: linux-clean busybox-clean u-boot-clean optee-os-clean \
+	optee-client-clean build-fit-clean optee-examples-clean
 cleaner: clean prepare-cleaner busybox-cleaner linux-cleaner
 
 -include toolchain.mk
@@ -73,13 +75,12 @@ xtest: xtest-common
 xtest-clean: xtest-clean-common
 xtest-patch: xtest-patch-common
 
-###############################################################################
-# hello_world
-###############################################################################
-.PHONY: helloworld helloworld-clean
+################################################################################
+# Sample applications / optee_examples
+################################################################################
+optee-examples: optee-examples-common
 
-helloworld: helloworld-common
-helloworld-clean: helloworld-clean-common
+optee-examples-clean: optee-examples-clean-common
 
 ###############################################################################
 # Busybox


### PR DESCRIPTION
New `optee_examples` git rep is used instead of `hello_world`, which will contain different sample applications that will show usage of specific TEE functionality (crypto examples, random data generation, trusted storage etc.)

Filelist of examples for rootfs is generated inside `optee_examples` `Makefile`
Currently, `example` targets are only defined inside `qemu.mk`

Relates to: https://github.com/linaro-swg/optee_examples/pull/1

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`