### PR TITLE
hikey_debian: Fix bug copying ta to deb package

### DIFF
--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -376,7 +376,7 @@ deb: prepare xtest optee-examples optee-client
 	@mkdir -p $(DEBPKG_LIB_PATH) && cd $(DEBPKG_LIB_PATH) && \
 		cp $(OPTEE_CLIENT_EXPORT)/lib/libtee* .
 	@mkdir -p $(DEBPKG_TA_PATH) && cd $(DEBPKG_TA_PATH) && \
-		cp $(HELLOWORLD_PATH)/ta/*.ta . && \
+		cp $(OPTEE_EXAMPLES_PATH)/out/ta/*.ta . && \
 		find $(OPTEE_TEST_OUT_PATH)/ta -name "*.ta" -exec cp {} . \;
 	@mkdir -p $(DEBPKG_CONTROL_PATH)
 	@echo "$$CONTROL_TEXT" > $(DEBPKG_CONTROL_PATH)/control


### PR DESCRIPTION
Commit 584efe5b ("examples: use optee_examples rep") missed this spot.

Signed-off-by: Victor Chong <victor.chong@linaro.org>