### PR TITLE
Move MULTIARCH def to common.mk/libyaml support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,6 +18,7 @@ OPTEE_TEST_PATH			?= $(ROOT)/optee_test
 OPTEE_TEST_OUT_PATH		?= $(ROOT)/optee_test/out
 OPTEE_EXAMPLES_PATH		?= $(ROOT)/optee_examples
 BENCHMARK_APP_PATH		?= $(ROOT)/optee_benchmark
+LIBYAML_LIB_PATH		?= $(BENCHMARK_APP_PATH)/libyaml/out/lib
 
 # default high verbosity. slow uarts shall specify lower if prefered
 CFG_TEE_CORE_LOG_LEVEL		?= 3
@@ -379,7 +380,8 @@ optee-examples-clean-common:
 ################################################################################
 BENCHMARK_APP_COMMON_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_USER) \
 	TEEC_EXPORT=$(OPTEE_CLIENT_EXPORT) \
-	TEEC_INTERNAL_INCLUDES=$(OPTEE_CLIENT_PATH)/libteec
+	TEEC_INTERNAL_INCLUDES=$(OPTEE_CLIENT_PATH)/libteec \
+	MULTIARCH=$(MULTIARCH)
 
 .PHONY: benchmark-app-common
 benchmark-app-common: optee-os optee-client
@@ -436,6 +438,10 @@ filelist-tee-common: optee-client xtest optee-examples
 	@if [ -e $(BENCHMARK_APP_PATH)/benchmark ]; then \
 		echo "file /bin/benchmark" \
 			"$(BENCHMARK_APP_PATH)/benchmark 755 0 0"	>> $(fl); \
+		echo "slink /lib/libyaml-0.so.2 libyaml-0.so.2.0.5 755 0 0" \
+									>> $(fl); \
+		echo "file /lib/libyaml-0.so.2.0.5 $(LIBYAML_LIB_PATH)/libyaml-0.so.2.0.5 755 0 0" \
+									>> $(fl); \
 	fi
 	@if [ "$(QEMU_USERNET_ENABLE)" = "y" ]; then \
 		echo "slink /etc/rc.d/S02_udhcp_networking /etc/init.d/udhcpc 755 0 0" \

--- a/common.mk
+++ b/common.mk
@@ -36,6 +36,16 @@ QEMU_VIRTFS_HOST_DIR	?= $(ROOT)
 
 # Enable SLiRP user networking
 QEMU_USERNET_ENABLE		?= n
+
+################################################################################
+# Mandatory for autotools (for specifying --host)
+################################################################################
+ifeq ($(COMPILE_NS_USER),64)
+MULTIARCH			:= aarch64-linux-gnu
+else
+MULTIARCH			:= arm-linux-gnueabihf
+endif
+
 ################################################################################
 # Check coherency of compilation mode
 ################################################################################

--- a/hikey.mk
+++ b/hikey.mk
@@ -21,15 +21,6 @@ CFG_FLASH_SIZE ?= 8
 -include common.mk
 
 ################################################################################
-# Mandatory definition to use common.mk
-################################################################################
-ifeq ($(COMPILE_NS_USER),64)
-MULTIARCH			:= aarch64-linux-gnu
-else
-MULTIARCH			:= arm-linux-gnueabihf
-endif
-
-################################################################################
 # Paths to git projects and various binaries
 ################################################################################
 ARM_TF_PATH			?= $(ROOT)/arm-trusted-firmware

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -17,15 +17,6 @@ CFG_CONSOLE_UART ?= 6
 -include common.mk
 
 ################################################################################
-# Mandatory definition to use common.mk
-################################################################################
-ifeq ($(COMPILE_NS_USER),64)
-MULTIARCH			:= aarch64-linux-gnu
-else
-MULTIARCH			:= arm-linux-gnueabihf
-endif
-
-################################################################################
 # Paths to git projects and various binaries
 ################################################################################
 ARM_TF_PATH			?= $(ROOT)/arm-trusted-firmware

--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -40,15 +40,6 @@ endif
 OPTEE_PKG_VERSION := $(shell cd $(OPTEE_OS_PATH) && git describe)-0
 
 ################################################################################
-# Mandatory definition to use common.mk
-################################################################################
-ifeq ($(COMPILE_NS_USER),64)
-MULTIARCH			:= aarch64-linux-gnu
-else
-MULTIARCH			:= arm-linux-gnueabihf
-endif
-
-################################################################################
 # Paths to git projects and various binaries
 ################################################################################
 ARM_TF_PATH			?= $(ROOT)/arm-trusted-firmware

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -18,15 +18,6 @@ RPI3_FIRMWARE_FILE_EXT = zip
 -include common.mk
 
 ################################################################################
-# Mandatory definition to use common.mk
-################################################################################
-ifeq ($(COMPILE_NS_USER),64)
-MULTIARCH			:= aarch64-linux-gnu
-else
-MULTIARCH			:= arm-linux-gnueabihf
-endif
-
-################################################################################
 # Paths to git projects and various binaries
 ################################################################################
 ARM_TF_PATH		?= $(ROOT)/arm-trusted-firmware


### PR DESCRIPTION
I'll create another PR in `optee_benchmark`, where libyaml is used for emitting timestamps data into the file (more convient for further parsing by python app + more user-friendly)

Relates to: https://github.com/linaro-swg/optee_benchmark/pull/3/

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`