### PR TITLE
Benchmark support for HiKey6220 and TI SoCs(am57xx, dra7xx)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,6 +24,9 @@ LIBYAML_LIB_PATH		?= $(BENCHMARK_APP_PATH)/libyaml/out/lib
 CFG_TEE_CORE_LOG_LEVEL		?= 3
 
 # default disable latency benchmarks (over all OP-TEE layers)
+# To be able to run benchmarks on TI platforms "OP-TEE Benchmark" patch 
+# for linux optee driver should be applied manually, CONFIG_OPTEE_BENCHMARK=y
+# flag should be added to ti_config_fragments/baseport.cfg.
 CFG_TEE_BENCHMARK			?= n
 
 CCACHE ?= $(shell which ccache) # Don't remove this comment (space is needed)

--- a/hikey.mk
+++ b/hikey.mk
@@ -51,6 +51,11 @@ PATCHES_PATH			?=$(ROOT)/patches_hikey
 ################################################################################
 # Targets
 ################################################################################
+ifeq ($(CFG_TEE_BENCHMARK),y)
+all: benchmark-app
+clean: benchmark-app-clean
+endif
+
 all: prepare arm-tf boot-img lloader nvme strace optee-examples
 
 clean: arm-tf-clean busybox-clean edk2-clean linux-clean optee-os-clean \
@@ -193,6 +198,13 @@ optee-client: optee-client-common
 
 .PHONY: optee-client-clean
 optee-client-clean: optee-client-clean-common
+
+################################################################################
+# optee_benchmark
+################################################################################
+benchmark-app: benchmark-app-common
+
+benchmark-app-clean: benchmark-app-clean-common
 
 ################################################################################
 # xtest / optee_test

--- a/ti/ti-common.mk
+++ b/ti/ti-common.mk
@@ -3,6 +3,10 @@
 ###############################################################################
 .PHONY: all clean cleaner prepare
 
+ifeq ($(CFG_TEE_BENCHMARK),y)
+all: benchmark-app
+clean: benchmark-app-clean
+endif
 all: u-boot linux optee-os optee-client xtest build-fit \
 	update_rootfs optee-examples
 clean: linux-clean busybox-clean u-boot-clean optee-os-clean \
@@ -93,6 +97,13 @@ BUSYBOX_CLEAN_COMMON_TARGET = $(BUSYBOX_COMMON_TARGET) clean
 busybox: busybox-common
 busybox-clean: busybox-clean-common
 busybox-cleaner: busybox-cleaner-common
+
+################################################################################
+# optee_benchmark
+################################################################################
+benchmark-app: benchmark-app-common
+
+benchmark-app-clean: benchmark-app-clean-common
 
 ###############################################################################
 # Build FIT


### PR DESCRIPTION
To be able to run benchmarks on TI platforms "OP-TEE Benchmark" patch         
for linux optee driver should be applied manually (as they are using their own linux fork), `CONFIG_OPTEE_BENCHMARK=y` flag should be added to `ti_config_fragments/baseport.cfg`.                   