### PR TITLE
qemu: fix "make check" to use OP-TEE image v2

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -42,7 +42,7 @@ info "Starting QEMU..."
 open "serial1.log" "w+"
 spawn -open [open "|tail -f serial1.log"]
 set teecore $spawn_id
-spawn ../qemu/arm-softmmu/qemu-system-arm -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -d unimp  -semihosting-config enable,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
 expect {
 	"Kernel panic" {
 		info "!!! Kernel panic\n"

--- a/qemu.mk
+++ b/qemu.mk
@@ -189,7 +189,9 @@ check-args += --timeout $(TIMEOUT)
 endif
 
 check: $(CHECK_DEPS)
-	expect qemu-check.exp -- $(check-args) || \
+	cd $(BINARIES_PATH) && \
+		export QEMU=$(ROOT)/qemu/arm-softmmu/qemu-system-arm && \
+		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \
 			echo "== $$PWD/serial0.log:"; \
 			cat serial0.log; \


### PR DESCRIPTION
Commit 37ab51d ("qemu: bios load OP-TEE image v2") has updated the run
and run-only targets, but not make check. Fix this.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>