### PR TITLE
hikey: add missing atf-fb dependency

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -364,7 +364,7 @@ atf-fb-clean:
 # l-loader
 ################################################################################
 .PHONY: lloader
-lloader:
+lloader: arm-tf atf-fb
 	cd $(LLOADER_PATH) && \
 		ln -sf $(ARM_TF_PATH)/build/hikey/$(ARM_TF_BUILD)/bl1.bin && \
 		ln -sf $(ATF_FB_PATH)/build/hikey/$(ATF_FB_BUILD)/bl1.bin fastboot.bin && \

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -336,7 +336,7 @@ boot-img-clean:
 # l-loader
 ################################################################################
 .PHONY: lloader
-lloader:
+lloader: arm-tf edk2
 	cd $(LLOADER_PATH) && \
 		ln -sf $(ARM_TF_PATH)/build/hikey960/$(ARM_TF_BUILD)/bl1.bin && \
 		ln -sf $(EDK2_BIN) && \


### PR DESCRIPTION
Adds missing atf-fb dependency to lloader.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>