### PR TITLE
qemu: use 4 virtual CPUs (-smp 4) for "make check"

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -42,7 +42,7 @@ info "Starting QEMU..."
 open "serial1.log" "w+"
 spawn -open [open "|tail -f serial1.log"]
 set teecore $spawn_id
-spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -d unimp  -semihosting-config enable,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp 4 -d unimp -semihosting-config enable,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
 expect {
 	"Kernel panic" {
 		info "!!! Kernel panic\n"


### PR DESCRIPTION
Now that OP-TEE supports several cores in QEMU, use 4 of them when
running "make check". This is hopefully more likely to catch any
concurrency bug.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>