### PR TITLE
qemu: build a statically linked version of QEMU

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -59,7 +59,7 @@ bios-qemu-clean:
 	$(call bios-qemu-common) clean
 
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu\
+	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu --static\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 	$(MAKE) -C $(QEMU_PATH)
 

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -75,7 +75,7 @@ arm-tf-clean:
 # QEMU
 ################################################################################
 qemu:
-	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu\
+	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu --static\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 	$(MAKE) -C $(QEMU_PATH)
 


### PR DESCRIPTION
Reduce the dependencies on the host environment.
It allows to reuse easily the binary built in other enviroment like
ramdisk and other CI environments.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>