### PR TITLE
qemu_v8.mk: remove ARM-TF flag: ERROR_DEPRECATED=1

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -54,7 +54,6 @@ ARM_TF_FLAGS ?= \
 	PLAT=qemu \
 	DEBUG=0 \
 	LOG_LEVEL=50 \
-	ERROR_DEPRECATED=1 \
 	BL32_RAM_LOCATION=tdram \
 	SPD=opteed
 


### PR DESCRIPTION
ERROR_DEPRECATED=1 may cause build errors when ARM deprecates APIs
upstream. Since we're tracking upstream master, it can happen at any
time, and indeed we have just met this build issue:

 plat/qemu/qemu_bl31_setup.c:129:2: error: unknown field 'g0_interrupt_num' specified in initializer
   .g0_interrupt_num = ARRAY_SIZE(irq_sec_array),
   ^

Although we usually want to use the latest APIs, having a build that
can break randomly is not nice to our users. Therefore, remove the
ERROR_DEPRECATED flag from our Makefile to fix the compile error and
give us some time to adapt to upstream changes.

Of course, the weakness in this reasoning is that by removing
ERROR_DEPRECATED, we are likely to not even notice when an API has
changed. Anyway, this seems to be the most reasonable option given that
there is no WARN_DEPRECATED flag.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>