### PR TITLE
juno: upload all the device tree blobs

### DIFF
--- a/juno.mk
+++ b/juno.mk
@@ -160,4 +160,6 @@ flash:
 	$(FTP-UPLOAD) $(ARM_TF_PATH)/build/juno/release/fip.bin
 	$(FTP-UPLOAD) $(ROOT)/linux/arch/arm64/boot/Image
 	$(FTP-UPLOAD) $(ROOT)/linux/arch/arm64/boot/dts/arm/juno.dtb
+	$(FTP-UPLOAD) $(ROOT)/linux/arch/arm64/boot/dts/arm/juno-r1.dtb
+	$(FTP-UPLOAD) $(ROOT)/linux/arch/arm64/boot/dts/arm/juno-r2.dtb
 	$(FTP-UPLOAD) $(ROOT)/gen_rootfs/ramdisk.img


### PR DESCRIPTION
It's assumed we have a Juno R0 board. It isn't always the case. If someone
has another revision, he'll prefer to use the right device tree for his
board.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>