### PR TITLE
FVP: Use official EDK2 and use boot image instead of semihosting

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -207,27 +207,21 @@ linux-cleaner-common: linux-defconfig-clean
 ################################################################################
 # EDK2 / Tianocore
 ################################################################################
-# Make sure edksetup.sh only will be called once and that we don't rebuild
-# BaseTools again and again.
-$(EDK2_PATH)/Conf/target.txt:
-	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
-	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools
-
 .PHONY: edk2-common
-edk2-common: $(EDK2_PATH)/Conf/target.txt
-	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
-	$(call edk2-call)
+edk2-common:
+	export WORKSPACE=$(ROOT) && \
+	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
+	source $(EDK2_PATH)/edksetup.sh && \
+	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools && \
+	$(call edk2-call) all
 
 .PHONY: edk2-clean-common
 edk2-clean-common:
-	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
-	$(call edk2-call) clean && \
-	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools clean
-	rm -rf $(EDK2_PATH)/Build
-	rm -rf $(EDK2_PATH)/Conf/.cache
-	rm -f $(EDK2_PATH)/Conf/build_rule.txt
-	rm -f $(EDK2_PATH)/Conf/target.txt
-	rm -f $(EDK2_PATH)/Conf/tools_def.txt
+	export WORKSPACE=$(ROOT) && \
+	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
+	source $(EDK2_PATH)/edksetup.sh && \
+	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools clean && \
+	$(call edk2-call) cleanall
 
 ################################################################################
 # QEMU / QEMUv8

--- a/fvp/grub/grub.cfg
+++ b/fvp/grub/grub.cfg
@@ -1,0 +1,10 @@
+set prefix='/EFI/BOOT'
+
+set default="0"
+set timeout=10
+
+menuentry 'GNU/Linux (OP-TEE)' {
+    linux /Image console=tty0 console=ttyAMA0,115200 earlycon=pl011,0x1c090000 root=/dev/disk/by-partlabel/system rootwait rw ignore_loglevel efi=noruntime
+    initrd /initrd.img
+    devicetree /foundation-v8.dtb
+}


### PR DESCRIPTION
This will move away from the old EDK2 landing team release and instead use latest and greatest from the official EDK2 tree(s). With this we are using a proper boot-image instead of relying on semihosting (which isn't supported in EDK2 anymore, which has only been on the Linaro landing-team branches).


To try this out one needs the commits in https://github.com/OP-TEE/manifest/pull/84. I.e., both this PR and the one in manifest.git needs to be merged at the same time.

If one want to try this on a local forest (just to show that this **can** be done with repo also, although I personally prefer [checking out the PR's from GitHub directly](https://help.github.com/articles/checking-out-pull-requests-locally/) instead, since that is just a oneliner), then one can:
```bash
$ repo init -u https://github.com/jbech-linaro/manifest.git -b fvp_grub -m fvp.xml
```

Create a folder `.repo/local_manifests/` and in there a file `foo.xml` containing:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<manifest>
        <remote name="jbech" fetch="https://github.com/jbech-linaro" />

        <remove-project path="build" name="build.git" />
        <project remote="jbech" path="build" name="build.git" revision="update_edk2">
                <linkfile src="fvp.mk" dest="build/Makefile" />
        </project>
</manifest>
```
And then sync again:
```bash
$ repo sync
```

Building and running are the same as before.