### PR TITLE
qemu v8: Use default path from edk2-platforms

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -209,15 +209,15 @@ linux-cleaner-common: linux-defconfig-clean
 ################################################################################
 .PHONY: edk2-common
 edk2-common:
-	export WORKSPACE=$(ROOT) && \
-	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
+	$(call edk2-env) && \
+	export PACKAGES_PATH=$(EDK2_PATH):$(EDK2_PLATFORMS_PATH) && \
 	source $(EDK2_PATH)/edksetup.sh && \
 	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools && \
 	$(call edk2-call) all
 
 .PHONY: edk2-clean-common
 edk2-clean-common:
-	export WORKSPACE=$(ROOT) && \
+	$(call edk2-env) && \
 	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
 	source $(EDK2_PATH)/edksetup.sh && \
 	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools clean && \

--- a/fvp.mk
+++ b/fvp.mk
@@ -18,8 +18,8 @@ include common.mk
 ################################################################################
 ARM_TF_PATH		?= $(ROOT)/arm-trusted-firmware
 EDK2_PATH		?= $(ROOT)/edk2
-EDK2_BIN		?= $(ROOT)/Build/ArmVExpress-FVP-AArch64/RELEASE_GCC49/FV/FVP_AARCH64_EFI.fd
 EDK2_PLATFORMS_PATH	?= $(ROOT)/edk2-platforms
+EDK2_BIN		?= $(EDK2_PLATFORMS_PATH)/Build/ArmVExpress-FVP-AArch64/RELEASE_GCC49/FV/FVP_AARCH64_EFI.fd
 FOUNDATION_PATH		?= $(ROOT)/Foundation_Platformpkg
 ifeq ($(wildcard $(FOUNDATION_PATH)),)
 $(error $(FOUNDATION_PATH) does not exist)
@@ -84,10 +84,14 @@ busybox-cleaner: busybox-cleaner-common
 ################################################################################
 # EDK2 / Tianocore
 ################################################################################
+define edk2-env
+	export WORKSPACE=$(EDK2_PLATFORMS_PATH)
+endef
+
 define edk2-call
 	GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
 	build -n `getconf _NPROCESSORS_ONLN` -a "AARCH64" \
-		-t "GCC49" -p $(EDK2_PLATFORMS_PATH)/Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc -b RELEASE
+		-t "GCC49" -p Platform/ARM/VExpressPkg/ArmVExpress-FVP-AArch64.dsc -b RELEASE
 endef
 
 edk2: edk2-common

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -97,6 +97,10 @@ busybox-cleaner: busybox-cleaner-common
 ################################################################################
 # EDK2 / Tianocore
 ################################################################################
+define edk2-env
+	export WORKSPACE=$(EDK2_PATH)
+endef
+
 define edk2-call
 	GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
 		$(MAKE) -j1 -C $(EDK2_PATH) \


### PR DESCRIPTION
With the introduction of edk2-platforms ([manifest/PR85](https://github.com/OP-TEE/manifest/pull/85)) we need to update the default edk2-platforms path to the built firmware.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>