### PR TITLE
[DO NOT MERGE] support build the secure key services components

### DIFF
--- a/br-ext/Config.in
+++ b/br-ext/Config.in
@@ -1,3 +1,4 @@
+source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_os/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_client/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_test/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_examples/Config.in"

--- a/br-ext/package/optee_os/Config.in
+++ b/br-ext/package/optee_os/Config.in
@@ -1,0 +1,45 @@
+config BR2_PACKAGE_OPTEE_OS
+	bool "optee_os"
+	select BR2_PACKAGE_OPENSSL
+	help
+	  http://github.org/OP-TEE/optee_os
+
+if BR2_PACKAGE_OPTEE_OS
+
+config BR2_PACKAGE_OPTEE_OS_PLATFORM
+	string "PLATFORM"
+	help
+	  Value for the PLATFORM directive provided to OP-TEE OS.
+
+config BR2_PACKAGE_OPTEE_OS_PLATFORM_FLAVOR
+	string "PLATFORM_FLAVOR"
+	help
+	  Value for the optional PLATFORM_FLAVOR directive provided to
+	  OP-TEE OS.
+
+
+config BR2_PACKAGE_OPTEE_OS_BUILD
+	bool "Build optee_os core and devkit from scratch"
+	default false
+	help
+	  If enabled, the OP-TEE OS core and trusted libraries.
+
+config BR2_PACKAGE_OPTEE_OS_SERVICES
+	bool "services from optee_os"
+	default false
+	help
+	  Build and embed the generic services trusted applications from
+	  optee_os.
+
+config BR2_PACKAGE_OPTEE_OS_SDK
+	string "OPTEE SDK path"
+	help
+	  If set, use the TA devkit path provided in configuration directive.
+
+config BR2_PACKAGE_OPTEE_OS_ADDITIONAL_VARIABLES
+	string "addition configuration directives
+	help
+	  Any additional configuration directives provided to OP-TEE OS, e.g
+	  "CFG_TEE_CODE_DEBUG=y CFG_TEE_CORE_LOG_LEVEL=3"
+endif
+

--- a/br-ext/package/optee_os/optee-os.mk
+++ b/br-ext/package/optee_os/optee-os.mk
@@ -1,0 +1,67 @@
+# TODO: get from config: $(call qstrip,$(BR2_OPTEE_OS_VERSION))
+OPTEE_OS_VERSION = 3.1
+
+OPTEE_OS_LICENSE = BSD-2-Clause
+OPTEE_OS_LICENSE_FILES = LICENSE
+
+OPTEE_OS_SOURCE = local
+OPTEE_OS_SITE = $(TOPDIR)/../optee_os
+OPTEE_OS_SITE_METHOD = local
+
+ifneq ($(BR2_PACKAGE_OPTEE_OS_SDK),)
+OPTEE_OS_SDK = $(BR2_PACKAGE_OPTEE_OS_SDK)
+else
+ifeq ($(BR2_aarch64),y)
+OPTEE_OS_SDK = ./out-br/export_ta_arm64
+else
+OPTEE_OS_SDK = ./out-br/export_ta_arm32
+endif
+endif
+
+OPTEE_OS_CONF_OPTS = -DOPTEE_TEST_SDK=$(OPTEE_OS_SDK)
+OPTEE_OS_MAKE_OPTS += CROSS_COMPILE=$(TARGET_CROSS)
+OPTEE_OS_MAKE_OPTS += CROSS_COMPILE_core=$(TARGET_CROSS)
+ifeq ($(BR2_aarch64),y)
+OPTEE_OS_MAKE_OPTS += CROSS_COMPILE_ta_arm64=$(TARGET_CROSS)
+endif
+ifeq ($(BR2_arm),y)
+OPTEE_OS_MAKE_OPTS += CROSS_COMPILE_ta_arm32=$(TARGET_CROSS)
+endif
+
+OPTEE_OS_MAKE_OPTS += PLATFORM=$(call qstrip,$(BR2_PACKAGE_OPTEE_OS_PLATFORM))
+OPTEE_OS_MAKE_OPTS += $(call qstrip,$(BR2_PACKAGE_OPTEE_OS_ADDITIONAL_VARIABLES))
+
+define OPTEE_OS_BUILD_CMDS
+	@echo Skip step as optee_os is built and installed outside buildroot
+	@echo $(@D)
+	@if [ "$(BR2_PACKAGE_OPTEE_OS_BUILD)" == y ]; then \
+		$(TARGET_CONFIGURE_OPTS) \
+			$(MAKE) -C $(@D) O=out-br $(OPTEE_OS_MAKE_OPTS) all; \
+	fi
+	@if [ "$(BR2_PACKAGE_OPTEE_OS_SERVICES)" == y ]; then \
+		$(foreach f,$(wildcard $(@D)/ta_services/*/Makefile), \
+		$(TARGET_CONFIGURE_OPTS) \
+			$(MAKE) CROSS_COMPILE=$(TARGET_CROSS) \
+				O=out-br TA_DEV_KIT_DIR=$(OPTEE_OS_SDK) \
+				-C $(dir $f) &&) true; \
+	fi
+endef
+
+define OPTEE_OS_INSTALL_IMAGES_CMDS
+	@if [ "$(BR2_PACKAGE_OPTEE_OS_BUILD)" == y ]; then \
+		mkdir -p $(BINARIES_DIR)/out-br-optee; \
+		cp -dpf $(@D)/out-br/core/tee-*_v2.bin $(BINARIES_DIR)/out-br-optee; \
+	fi
+	@if [ "$(BR2_PACKAGE_OPTEE_OS_SERVICES)" == y ]; then \
+		mkdir -p $(TARGET_DIR)/lib/optee_armtz; \
+		$(foreach f,$(wildcard $(@D)/ta_services/*/out-br/*.ta), \
+			$(INSTALL) -v -p  --mode=444 \
+				--target-directory=$(TARGET_DIR)/lib/optee_armtz \
+				 $f &&) true; \
+	fi
+endef
+
+OPTEE_OS_INSTALL_STAGING = YES
+OPTEE_OS_INSTALL_IMAGES = YES
+
+$(eval $(generic-package))

--- a/common.mk
+++ b/common.mk
@@ -222,6 +222,11 @@ buildroot: optee-os
 ifeq ($(CFG_TEE_BENCHMARK),y)
 	@echo "BR2_PACKAGE_OPTEE_BENCHMARK=y" >> ../out-br/extra.conf
 endif
+	@echo "BR2_PACKAGE_OPTEE_OS=y" >> ../out-br/extra.conf
+	@echo "BR2_PACKAGE_OPTEE_OS_BUILD=n" >> ../out-br/extra.conf
+	@echo "BR2_PACKAGE_OPTEE_OS_SERVICES=y" >> ../out-br/extra.conf
+	@echo "BR2_PACKAGE_OPTEE_OS_SDK=\"$(OPTEE_OS_TA_DEV_KIT_DIR)\"" >> \
+		../out-br/extra.conf
 	@(cd .. && python build/br-ext/scripts/make_def_config.py \
 		--br buildroot --out out-br --br-ext build/br-ext \
 		--top-dir "$(ROOT)" \


### PR DESCRIPTION
This change allow to build the secure key services components, currently on the Qemu/armv7 OP-TEE setup. Note that these component are not available in the OP-TEE release. One must get from the private git repositories:

~~Library and test application from https://github.com/etienne-lms/sks_lib.~~
~~Trusted application from https://github.com/etienne-lms/sks_ta.~~

**Updated reference: go fetch from my private github:**
Trusted application : https://github.com/etienne-lms/optee_os, branch **sks**.
Pkcs11 client library: https://github.com/etienne-lms/optee_client, branch **sks**.
Test support in xtest: https://github.com/etienne-lms/optee_test, branch **sks**.

These are work in progress...