### PR TITLE
strace: Disable multiple personality support

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -249,7 +249,7 @@ strace:
 	cd $(STRACE_PATH); \
 	./bootstrap; \
 	set -e; \
-	./configure --host=$(MULTIARCH) CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld; \
+	./configure --host=$(MULTIARCH) --enable-mpers=no CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld; \
 	CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld $(MAKE) -C $(STRACE_PATH)
 
 .PHONY: strace-clean

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -239,7 +239,7 @@ strace:
 	cd $(STRACE_PATH); \
 	./bootstrap; \
 	set -e; \
-	./configure --host=$(MULTIARCH) CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld; \
+	./configure --host=$(MULTIARCH) --enable-mpers=no CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld; \
 	CC="$(CCACHE)$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)gcc" LD=$(AARCH$(COMPILE_NS_USER)_CROSS_COMPILE)ld $(MAKE) -C $(STRACE_PATH)
 
 .PHONY: strace-clean

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -186,7 +186,8 @@ strace:
 ifneq ("$(wildcard $(STRACE_PATH))","")
 		cd $(STRACE_PATH) && \
 		./bootstrap && \
-		./configure --host=aarch64-linux-gnu CC=$(CROSS_COMPILE_NS_USER)gcc && \
+		./configure --host=aarch64-linux-gnu CC=$(CROSS_COMPILE_NS_USER)gcc \
+			--enable-mpers=no && \
 		CC=$(CROSS_COMPILE_NS_USER)gcc $(MAKE)
 endif
 


### PR DESCRIPTION
Travis seems to [be happy with this fix](https://travis-ci.org/jbech-linaro/build/builds/329375926) and this resolves the [build issue](https://travis-ci.org/OP-TEE/build/builds/329285971) showing up on the daily build last night.

Multiple personality support in strace is not something that we make use
of in OP-TEE for the moment, so instead of putting more prerequisites on
our builds let us just disable this feature in strace.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>