### PR TITLE
qemu_v8: fix missing edk2 'cleanall' target

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -112,7 +112,12 @@ endef
 
 edk2: edk2-common
 
-edk2-clean: edk2-clean-common
+edk2-clean:
+	$(call edk2-env) && \
+	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
+	source $(EDK2_PATH)/edksetup.sh && \
+	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools clean && \
+	$(call edk2-call) clean
 
 
 


### PR DESCRIPTION
The edk2-clean-common target in common.mk uses a cleanall target, which does
not exist in the makefile used by edk2-call in qemu_v8.mk. Adding a specific
target for edk2-clean in qemu_v8.mk that uses 'clean' instead of 'cleanall'
allows the clean target to complete successfully.

Signed-off-by: Joel Anderson <jeander@vt.edu>