### PR TITLE
qemu_v8.mk: update edk2-call to invoke the EDK2 build script

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -102,12 +102,10 @@ define edk2-env
 endef
 
 define edk2-call
-	GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
-		$(MAKE) -j1 -C $(EDK2_PATH) \
-		-f ArmPlatformPkg/Scripts/Makefile EDK2_ARCH=AARCH64 \
-		EDK2_DSC=ArmVirtPkg/ArmVirtQemuKernel.dsc \
-		EDK2_TOOLCHAIN=GCC49 EDK2_BUILD=DEBUG \
-		EDK2_MACROS="-n 6"
+        GCC49_AARCH64_PREFIX=$(LEGACY_AARCH64_CROSS_COMPILE) \
+        build -n `getconf _NPROCESSORS_ONLN` -a AARCH64 \
+                -t GCC49 -p ArmVirtPkg/ArmVirtQemuKernel.dsc \
+		-b DEBUG
 endef
 
 edk2: edk2-common


### PR DESCRIPTION
Like other platforms (fvp.mk, hikey.mk, hikey960.mk, hikey_debian.mk)
define the edk2-call macro to invoke the EDK2 build script rather than
$(MAKE) directly. Indeed, the edk2-clean-common target in common.mk
expects $(edk2-call) to take the 'cleanall' argument, which the EDK2
build script does accept, but the EDK2 makefile doesn't (there is no
cleanall rule in EDK2).

Fixes:

 $ make clean
 [...]
 make[1]: Entering directory '/home/jerome/optee_repo_qemu_v8/edk2'
 make[1]: *** No rule to make target 'cleanall'.  Stop.

Another option to fix the above error would be to change the edk2-clean
target to no use edk2-clean-common and call "$(MAKE) clean" directly.
But then, it would be inconsistent with other platforms and the EDK2
build script may be a better interface than raw make (more stable).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Joel Anderson <jeander@vt.edu>