### PR TITLE
qemu_v8.mk: update strace-clean to test for Makefile

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -193,9 +193,11 @@ endif
 
 strace-clean:
 ifneq ("$(wildcard $(STRACE_PATH))","")
-		CC=$(CROSS_COMPILE_NS_USER)gcc \
-			$(MAKE) -C $(STRACE_PATH) clean && \
-		rm -f $(STRACE_PATH)/Makefile $(STRACE_PATH)/configure
+		if [ -e $(STRACE_PATH)/Makefile ] ; then \
+			CC=$(CROSS_COMPILE_NS_USER)gcc \
+				$(MAKE) -C $(STRACE_PATH) clean && \
+			rm -f $(STRACE_PATH)/Makefile $(STRACE_PATH)/configure; \
+		fi
 endif
 
 ################################################################################


### PR DESCRIPTION
The 'strace-clean' target runs the 'clean' target in the strace project
directly, and afterwards removes the Makefile and configure scripts as well.
This is the same strategy used by other platforms using strace (hikey.mk and
hikey960.mk), however other platforms check for the existence of the Makefile
before executing $(MAKE), allowing a build to be cleaned multiple times.
Without this check, subsequent invocations of 'strace-clean' (or simply
'clean') fail as there is no Makefile to use.

Fixes:

$ make strace-clean
[...]
$ make strace-clean
[...]
make[1]: Entering directory '/home/goatshriek/optee-armv8/strace'
make[1]: *** No rule to make target 'clean'.  Stop.

Signed-off-by: Joel Anderson <jeander@vt.edu>