### PR TITLE
travis: rename the github remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,6 @@ script:
                 slug=$TRAVIS_REPO_SLUG
                 branch=$TRAVIS_BRANCH
         fi
-  - cd $HOME/$REPO_PROJ/build && git remote add github https://github.com/$slug && git remote update
-  - cd $HOME/$REPO_PROJ/build && git checkout github/$branch
+  - cd $HOME/$REPO_PROJ/build && git remote add github_remote https://github.com/$slug && git remote update
+  - cd $HOME/$REPO_PROJ/build && git checkout github_remote/$branch
   - cd $HOME/$REPO_PROJ/build && make -f toolchain.mk toolchains -j3 && make all -j`nproc`


### PR DESCRIPTION
With the recent QEMU v7 changes in manifest.git:
  918f04199c ("qemu: general cleanup and remote changes")
where the remote "github" was introduced, we introduced a regression for
the QEMU v7 Travis builds. The remote name "github" has been used in
Travis when setting up a remote for the build.git itself. By renaming
the remote we do not get any naming collisions and the Travis build
script will be prepared for similar changes in manifest.git for the
other platforms.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>