### PR TITLE
hikey, hikey960: make bl2.bin available to l-loader

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -367,6 +367,7 @@ atf-fb-clean:
 lloader: arm-tf atf-fb
 	cd $(LLOADER_PATH) && \
 		ln -sf $(ARM_TF_PATH)/build/hikey/$(ARM_TF_BUILD)/bl1.bin && \
+		ln -sf $(ARM_TF_PATH)/build/hikey/$(ARM_TF_BUILD)/bl2.bin && \
 		ln -sf $(ATF_FB_PATH)/build/hikey/$(ATF_FB_BUILD)/bl1.bin fastboot.bin && \
 		$(MAKE) hikey PTABLE_LST=linux-$(CFG_FLASH_SIZE)g CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -339,6 +339,7 @@ boot-img-clean:
 lloader: arm-tf edk2
 	cd $(LLOADER_PATH) && \
 		ln -sf $(ARM_TF_PATH)/build/hikey960/$(ARM_TF_BUILD)/bl1.bin && \
+		ln -sf $(ARM_TF_PATH)/build/hikey960/$(ARM_TF_BUILD)/bl2.bin && \
 		ln -sf $(EDK2_BIN) && \
 		$(MAKE) hikey960 PTABLE_LST=linux-32g
 


### PR DESCRIPTION
The latest version of l-loader apparently needs bl2.bin in addition to
bl1.bin. Fixes the following error:

 make[2]: Entering directory '/home/optee/devel/hikey/l-loader'
 /usr/bin/ccache /home/optee/devel/hikey/build/../toolchains/aarch32/bin/arm-linux-gnueabihf-gcc  -c -o start.o start.S
 make[2]: *** No rule to make target 'bl2.bin', needed by 'l-loader.bin'.  Stop.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>