### PR TITLE
qemu-check.exp: fix expected prompts

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -52,14 +52,14 @@ expect {
 		info "!!! Timeout\n"
 		exit 1
 	}
-	"Please press Enter to activate this console. "
+	"ogin:"
 }
-send -- "\r"
-expect "root@Vexpress:/ "
+send -- "root\r\r"
+expect "# "
 info " done, guest is booted.\n"
 # Toolchain libraries might be here or there
 send -- "export LD_LIBRARY_PATH=/lib:/lib/arm-linux-gnueabihf\r"
-expect "root@Vexpress:/ "
+expect "# "
 info "Running: $cmd...\n"
 send -- "$cmd\r"
 set casenum "none"


### PR DESCRIPTION
Since commit eed314d11475 ("qemu: build using buildroot"), the login
and the shell prompts of the root FS have changed. Adjust our "make
check" accordingly.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>