### PR TITLE
travis: remove MTK8173 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,8 @@ env:
   - $REPO_PROJ=hikey
   - $REPO_PROJ=hikey960
   - $REPO_PROJ=juno
-  - $REPO_PROJ=mt8173-evb
   - $REPO_PROJ=qemu_v8
   - $REPO_PROJ=rpi3
-  #- $REPO_PROJ=dra7xx # Cannot build this since it requires TI_SECURE_DEV_PKG
 
 before_script:
   - mkdir -p $HOME/bin


### PR DESCRIPTION
MTK8173 in manifest.git has just recently been deprecated and therefore
we need to remove it from Travis.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>