### PR TITLE
hikey960.mk: fix name of hisi-sec_xloader.img

### DIFF
--- a/hikey960.mk
+++ b/hikey960.mk
@@ -415,7 +415,7 @@ endif
 	@read -r -p "Then press enter to continue flashing" dummy
 	@echo
 	fastboot flash ptable $(LLOADER_PATH)/prm_ptable.img
-	fastboot flash xloader $(IMAGE_TOOLS_PATH)/sec_xloader.img
+	fastboot flash xloader $(IMAGE_TOOLS_PATH)/hisi-sec_xloader.img
 	fastboot flash fastboot $(LLOADER_PATH)/l-loader.bin
 	fastboot flash fip $(ARM_TF_PATH)/build/hikey960/$(ARM_TF_BUILD)/fip.bin
 	fastboot flash nvme $(IMAGE_TOOLS_PATH)/hisi-nvme.img


### PR DESCRIPTION
Commit f9f39124efd1 ("hikey*: support migration to BL2_EL3 on arm-tf")
has updated the flash target to use hisi-nvme.img instead of nvme.img,
thus adopting the new naming introduced by upstream commit b5ae2c13438e
("installer: add hisi- prefix to ptable, sec_xloader, fastboot,
sec_uce_boot, and sec_usb_xloader imgs").
Unfortunately, the line dealing with sec_xloader.img was not updated.
Do it to fix "make flash".

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>