### PR TITLE
qemu_virt: boot from arm-tf and allow smp test

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -14,10 +14,9 @@ include common.mk
 # Paths to git projects and various binaries
 ################################################################################
 ARM_TF_PATH			?= $(ROOT)/arm-trusted-firmware
+BINARIES_PATH			?= $(ROOT)/out/bin
 BIOS_QEMU_PATH			?= $(ROOT)/bios_qemu_tz_arm
 QEMU_PATH			?= $(ROOT)/qemu
-BINARIES_PATH			?= $(ROOT)/out/bin
-
 SOC_TERM_PATH			?= $(ROOT)/soc_term
 
 DEBUG = 1
@@ -25,9 +24,9 @@ DEBUG = 1
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf bios-qemu qemu soc-term linux
-clean: arm-tf-clean bios-qemu-clean linux-clean optee-os-clean \
-	qemu-clean soc-term-clean check-clean buildroot-clean
+all: arm-tf bios-qemu buildroot linux optee-os qemu soc-term
+clean: arm-tf-clean bios-qemu-clean buildroot-clean linux-clean optee-os-clean \
+	qemu-clean soc-term-clean check-clean
 
 include toolchain.mk
 
@@ -84,7 +83,7 @@ define bios-qemu-common
 		PLATFORM_FLAVOR=virt
 endef
 
-bios-qemu: buildroot optee-os linux
+bios-qemu:
 	$(call bios-qemu-common)
 	ln -sf $(ROOT)/out/bios-qemu/bios.bin $(BINARIES_PATH)
 

--- a/qemu.mk
+++ b/qemu.mk
@@ -155,6 +155,8 @@ run: all
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(MAKE) run-only
 
+QEMU_SMP ?= 1
+
 .PHONY: run-only
 run-only:
 	$(call check-terminal)
@@ -165,6 +167,7 @@ run-only:
 	(cd $(BINARIES_PATH) && $(QEMU_PATH)/arm-softmmu/qemu-system-arm \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-smp $(QEMU_SMP) \
 		-s -S -machine virt -machine secure=on -cpu cortex-a15 \
 		-d unimp  -semihosting-config enable,target=native \
 		-m 1057 \
@@ -181,7 +184,6 @@ ifneq ($(TIMEOUT),)
 check-args += --timeout $(TIMEOUT)
 endif
 
-QEMU_SMP ?= 1
 check: $(CHECK_DEPS)
 	cd $(BINARIES_PATH) && \
 		export QEMU=$(ROOT)/qemu/arm-softmmu/qemu-system-arm && \

--- a/qemu.mk
+++ b/qemu.mk
@@ -13,6 +13,7 @@ include common.mk
 ################################################################################
 # Paths to git projects and various binaries
 ################################################################################
+ARM_TF_PATH			?= $(ROOT)/arm-trusted-firmware
 BIOS_QEMU_PATH			?= $(ROOT)/bios_qemu_tz_arm
 QEMU_PATH			?= $(ROOT)/qemu
 BINARIES_PATH			?= $(ROOT)/out/bin
@@ -24,11 +25,54 @@ DEBUG = 1
 ################################################################################
 # Targets
 ################################################################################
-all: bios-qemu qemu soc-term linux
-clean: bios-qemu-clean linux-clean optee-os-clean \
+all: arm-tf bios-qemu qemu soc-term linux
+clean: arm-tf-clean bios-qemu-clean linux-clean optee-os-clean \
 	qemu-clean soc-term-clean check-clean buildroot-clean
 
 include toolchain.mk
+
+################################################################################
+# ARM Trusted Firmware
+################################################################################
+ARM_TF_EXPORTS ?= \
+	CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
+
+ARM_TF_DEBUG ?= $(DEBUG)
+ifeq ($(ARM_TF_DEBUG),0)
+ARM_TF_LOGLVL ?= 30
+ARM_TF_OUT = $(ARM_TF_PATH)/build/qemu/release
+else
+ARM_TF_LOGLVL ?= 50
+ARM_TF_OUT = $(ARM_TF_PATH)/build/qemu/debug
+endif
+
+ARM_TF_FLAGS ?= \
+	BL32=$(OPTEE_OS_HEADER_V2_BIN) \
+	BL32_EXTRA1=$(OPTEE_OS_PAGER_V2_BIN) \
+	BL32_EXTRA2=$(OPTEE_OS_PAGEABLE_V2_BIN) \
+	BL33=$(ROOT)/out/bios-qemu/bios.bin \
+	ARM_ARCH_MAJOR=7 \
+	ARCH=aarch32 \
+	PLAT=qemu \
+	DEBUG=$(ARM_TF_DEBUG) \
+	ENABLE_ASSERTIONS=$(ARM_TF_DEBUG) \
+	LOG_LEVEL=$(ARM_TF_LOGLVL) \
+	MULTI_CONSOLE_API=0 \
+	ARM_TSP_RAM_LOCATION=tdram \
+	BL32_RAM_LOCATION=tdram \
+	AARCH32_SP=optee
+
+arm-tf: optee-os bios-qemu
+	$(ARM_TF_EXPORTS) $(MAKE) -C $(ARM_TF_PATH) $(ARM_TF_FLAGS) all fip
+	ln -sf $(ARM_TF_OUT)/bl1.bin $(BINARIES_PATH)
+	ln -sf $(ARM_TF_OUT)/bl2.bin $(BINARIES_PATH)
+	ln -sf $(OPTEE_OS_HEADER_V2_BIN) $(BINARIES_PATH)/bl32.bin
+	ln -sf $(OPTEE_OS_PAGER_V2_BIN) $(BINARIES_PATH)/bl32_extra1.bin
+	ln -sf $(OPTEE_OS_PAGEABLE_V2_BIN) $(BINARIES_PATH)/bl32_extra2.bin
+	ln -sf $(ROOT)/out/bios-qemu/bios.bin $(BINARIES_PATH)/bl33.bin
+
+arm-tf-clean:
+	$(ARM_TF_EXPORTS) $(MAKE) -C $(ARM_TF_PATH) $(ARM_TF_FLAGS) clean
 
 ################################################################################
 # QEMU
@@ -41,13 +85,8 @@ define bios-qemu-common
 endef
 
 bios-qemu: buildroot optee-os linux
-	mkdir -p $(BINARIES_PATH)
-	ln -sf $(OPTEE_OS_HEADER_V2_BIN) $(BINARIES_PATH)
-	ln -sf $(OPTEE_OS_PAGER_V2_BIN) $(BINARIES_PATH)
-	ln -sf $(OPTEE_OS_PAGEABLE_V2_BIN) $(BINARIES_PATH)
-	ln -sf $(LINUX_PATH)/arch/arm/boot/zImage $(BINARIES_PATH)
-	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)
 	$(call bios-qemu-common)
+	ln -sf $(ROOT)/out/bios-qemu/bios.bin $(BINARIES_PATH)
 
 bios-qemu-clean:
 	$(call bios-qemu-common) clean
@@ -73,6 +112,8 @@ linux-defconfig: $(LINUX_PATH)/.config
 LINUX_COMMON_FLAGS += ARCH=arm
 
 linux: linux-common
+	mkdir -p $(BINARIES_PATH)
+	ln -sf $(LINUX_PATH)/arch/arm/boot/zImage $(BINARIES_PATH)
 
 linux-defconfig-clean: linux-defconfig-clean-common
 
@@ -112,6 +153,7 @@ soc-term-clean:
 .PHONY: run
 # This target enforces updating root fs etc
 run: all
+	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(MAKE) run-only
 
 .PHONY: run-only
@@ -127,7 +169,7 @@ run-only:
 		-s -S -machine virt -machine secure=on -cpu cortex-a15 \
 		-d unimp  -semihosting-config enable,target=native \
 		-m 1057 \
-		-bios $(ROOT)/out/bios-qemu/bios.bin \
+		-bios bl1.bin \
 		$(QEMU_EXTRA_ARGS) )
 
 


### PR DESCRIPTION
This build arm-trusted-firmware for qemu cortex-a15.
bios_qemu_tz_arm is still used as the primary non-secure boot stage.

Depends on https://github.com/OP-TEE/manifest/pull/110.