### PR TITLE
qemu/qemu_v8: dependecy for make targets 'check'

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ target you will use in the end.
 
 ```bash
 $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
-	automake bc bison build-essential cscope curl device-tree-compiler flex \
-	ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev libfdt-dev \
-	libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev \
+	automake bc bison build-essential cscope curl device-tree-compiler \
+	expect flex ftp-upload gdisk iasl libattr1-dev libc6:i386 libcap-dev \
+	libfdt-dev libftdi-dev libglib2.0-dev libhidapi-dev libncurses5-dev \
 	libpixman-1-dev libssl-dev libstdc++6:i386 libtool libz1:i386 make \
 	mtools netcat python-crypto python-serial python-wand unzip uuid-dev \
 	xdg-utils xterm xz-utils zlib1g-dev


### PR DESCRIPTION
Checking Qemu arguments expects the tool 'expect'.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>