### PR TITLE
qemu: make check: create symlink to rootfs.cpio.gz

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -187,6 +187,7 @@ check-args += --timeout $(TIMEOUT)
 endif
 
 check: $(CHECK_DEPS)
+	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	cd $(BINARIES_PATH) && \
 		export QEMU=$(ROOT)/qemu/arm-softmmu/qemu-system-arm && \
 		export QEMU_SMP=$(QEMU_SMP) && \


### PR DESCRIPTION
Now that Arm Trusted Firmware is used as the secure boot loader
and bios_qemu_tz_arm is used as the non-secure bootloader, all binaries
are expected to be found in the $(BINARIES) directory. Symbolic links
are created by various targets in the qemu.mk.
The 'check' target should create a link to rootfs.cpio.gz, similar to
the 'run' target.

Fixes: 46ddff2b339b9 ("qemu: boot from arm-tf")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>