### PR TITLE
am32xx am57xx dra7xx: build using buildroot

### DIFF
--- a/am43xx.mk
+++ b/am43xx.mk
@@ -8,6 +8,9 @@ override COMPILE_NS_KERNEL := 32
 override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
+# Need to set this before including common.mk
+BUILDROOT_GETTY_PORT ?= ttyS0
+
 ###############################################################################
 # Includes
 ###############################################################################
@@ -28,7 +31,6 @@ FIT_MAKEFILE    ?= $(BUILD_PATH)/ti/Makefile
 OPTEE_PLATFORM  ?= ti-am43xx
 U-BOOT_CONFIG   ?= am43xx_hs_evm_defconfig
 CONFIG_TYPE     ?= ti_sdk_am4x_debug
-BUSYBOX_TARGET  ?= am43xx
 
 ###############################################################################
 # Include common to TI builds

--- a/am57xx.mk
+++ b/am57xx.mk
@@ -8,6 +8,9 @@ override COMPILE_NS_KERNEL := 32
 override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
+# Need to set this before including common.mk
+BUILDROOT_GETTY_PORT ?= ttyS2
+
 ###############################################################################
 # Includes
 ###############################################################################
@@ -29,7 +32,6 @@ OPTEE_PLATFORM  ?= ti-am57xx
 U-BOOT_CONFIG   ?= am57xx_hs_evm_defconfig
 # using the same configs as for DRA7xx
 CONFIG_TYPE     ?= ti_sdk_dra7x_debug
-BUSYBOX_TARGET  ?= dra7xx
 
 ###############################################################################
 # Include common to TI builds

--- a/common.mk
+++ b/common.mk
@@ -20,6 +20,7 @@ OPTEE_EXAMPLES_PATH		?= $(ROOT)/optee_examples
 BENCHMARK_APP_PATH		?= $(ROOT)/optee_benchmark
 BENCHMARK_APP_OUT		?= $(BENCHMARK_APP_PATH)/out
 LIBYAML_LIB_OUT			?= $(BENCHMARK_APP_OUT)/libyaml/out/lib
+BUILDROOT_TARGET_ROOT		?= $(ROOT)/out-br/target
 
 # default high verbosity. slow uarts shall specify lower if prefered
 CFG_TEE_CORE_LOG_LEVEL		?= 3

--- a/dra7xx.mk
+++ b/dra7xx.mk
@@ -8,6 +8,9 @@ override COMPILE_NS_KERNEL := 32
 override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
+# Need to set this before including common.mk
+BUILDROOT_GETTY_PORT ?= ttyS0
+
 ###############################################################################
 # Includes
 ###############################################################################
@@ -28,7 +31,6 @@ FIT_MAKEFILE    ?= $(BUILD_PATH)/ti/Makefile
 OPTEE_PLATFORM  ?= ti-dra7xx
 U-BOOT_CONFIG   ?= dra7xx_hs_evm_defconfig
 CONFIG_TYPE     ?= ti_sdk_dra7x_debug
-BUSYBOX_TARGET  ?= dra7xx
 
 ###############################################################################
 # Include common to TI builds


### PR DESCRIPTION
Changes for the TI platforms to use buildroot instead. I'm not able to test this myself. @igoropaniuk, @glneo, can you help?

To build this:
```
repo init -u https://github.com/jenswi-linaro/manifest.git -m dra7xx.xml -b remaining-br
cd build
git remote add jenswi https://github.com/jenswi-linaro/build.git
git fetch jenswi
git checkout jenswi/remaining-br
```
then build and flash as usual.
