### PR TITLE
qemu_v8: ease SMP testing through QEMU_SMP

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -152,6 +152,8 @@ soc-term-clean:
 run: all
 	$(MAKE) run-only
 
+QEMU_SMP ?= 1
+
 .PHONY: run-only
 run-only:
 	$(call check-terminal)
@@ -163,6 +165,7 @@ run-only:
 	$(QEMU_PATH)/aarch64-softmmu/qemu-system-aarch64 \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-smp $(QEMU_SMP) \
 		-machine virt,secure=on -cpu cortex-a57 -m 1057 -bios $(ARM_TF_PATH)/build/qemu/release/bl1.bin \
 		-s -S -semihosting-config enable,target=native -d unimp \
 		-initrd $(ROOT)/out-br/images/rootfs.cpio.gz \


### PR DESCRIPTION
As for qemu.mk, environment can set the number of cores to be emulated
using QEMU_SMP. Defaults to 1 core.

This change is relates to https://github.com/OP-TEE/optee_os/pull/2339 and eases testing qemu_v8 over more cores.