### PR TITLE
Rpi3: build using Buildroot

### DIFF
--- a/docs/rpi3.md
+++ b/docs/rpi3.md
@@ -195,12 +195,12 @@ lrwxrwxrwx  1 jbech  jbech         90 Sep 13 11:19 bcm2710-rpi-3-b.dtb -> /home/
 
 ### 5.3.2 The root FS
 We are now going to put the root fs on the location we prepared in the previous
-section (5.2). The path to the `filesystem.cpio.gz` will differ on your machine,
+section (5.2). The path to the `rootfs.cpio.gz` will differ on your machine,
 so update accordingly.
 
 ```bash
 $ cd /srv/nfs/rpi
-$ sudo gunzip -cd /home/jbech/devel/optee_projects/rpi3/build/../gen_rootfs/filesystem.cpio.gz | sudo cpio -idmv
+$ sudo gunzip -cd /home/jbech/devel/optee_projects/rpi3/out-br/images/rootfs.cpio.gz | sudo cpio -idmv
 $ sudo rm -rf /srv/nfs/rpi/boot/*
 ```
 

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -27,14 +27,14 @@ U-BOOT_PATH		?= $(ROOT)/u-boot
 U-BOOT_BIN		?= $(U-BOOT_PATH)/u-boot.bin
 U-BOOT_RPI_BIN		?= $(U-BOOT_PATH)/u-boot-rpi.bin
 
-RPI3_FIRMWARE_PATH		?= $(BUILD_PATH)/rpi3/firmware
-RPI3_HEAD_BIN			?= $(ROOT)/out/head.bin
-RPI3_BOOT_CONFIG		?= $(RPI3_FIRMWARE_PATH)/config.txt
-RPI3_UBOOT_ENV			?= $(ROOT)/out/uboot.env
-RPI3_UBOOT_ENV_TXT		?= $(RPI3_FIRMWARE_PATH)/uboot.env.txt
-RPI3_STOCK_FW_PATH		?= $(ROOT)/firmware
+RPI3_FIRMWARE_PATH	?= $(BUILD_PATH)/rpi3/firmware
+RPI3_HEAD_BIN		?= $(ROOT)/out/head.bin
+RPI3_BOOT_CONFIG	?= $(RPI3_FIRMWARE_PATH)/config.txt
+RPI3_UBOOT_ENV		?= $(ROOT)/out/uboot.env
+RPI3_UBOOT_ENV_TXT	?= $(RPI3_FIRMWARE_PATH)/uboot.env.txt
+RPI3_STOCK_FW_PATH	?= $(ROOT)/firmware
 RPI3_STOCK_FW_PATH_BOOT	?= $(RPI3_STOCK_FW_PATH)/boot
-OPTEE_OS_PAGER			?= $(OPTEE_OS_PATH)/out/arm/core/tee-pager.bin
+OPTEE_OS_PAGER		?= $(OPTEE_OS_PATH)/out/arm/core/tee-pager.bin
 
 LINUX_IMAGE		?= $(LINUX_PATH)/arch/arm64/boot/Image
 LINUX_DTB		?= $(LINUX_PATH)/arch/arm64/boot/dts/broadcom/bcm2710-rpi-3-b.dtb

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -8,6 +8,9 @@ override COMPILE_NS_KERNEL := 64
 override COMPILE_S_USER    := 64
 override COMPILE_S_KERNEL  := 64
 
+# Need to set this before including common.mk
+BUILDROOT_GETTY_PORT ?= ttyS0
+
 include common.mk
 
 ################################################################################

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -40,15 +40,10 @@ MODULE_OUTPUT		?= $(ROOT)/module_output
 ################################################################################
 # Targets
 ################################################################################
-ifeq ($(CFG_TEE_BENCHMARK),y)
-all: benchmark-app
-clean: benchmark-app-clean
-endif
-all: arm-tf optee-os optee-client xtest u-boot u-boot-rpi-bin\
-	linux update_rootfs optee-examples
-clean: arm-tf-clean busybox-clean u-boot-clean u-boot-rpi-bin-clean \
-	optee-os-clean optee-client-clean head-bin-clean \
-	optee-examples-clean
+all: arm-tf buildroot optee-os u-boot u-boot-rpi-bin \
+	linux update_rootfs
+clean: arm-tf-clean buildroot-clean u-boot-clean u-boot-rpi-bin-clean \
+	optee-os-clean head-bin-clean
 
 include toolchain.mk
 
@@ -160,64 +155,34 @@ optee-os: optee-os-common
 OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=rpi3
 optee-os-clean: optee-os-clean-common
 
-optee-client: optee-client-common
-
-optee-client-clean: optee-client-clean-common
-
-################################################################################
-# xtest / optee_test
-################################################################################
-xtest: xtest-common
-
-xtest-clean: xtest-clean-common
-
-xtest-patch: xtest-patch-common
-
-################################################################################
-# Sample applications / optee_examples
-################################################################################
-optee-examples: optee-examples-common
-
-optee-examples-clean: optee-examples-clean-common
-
-################################################################################
-# benchmark
-################################################################################
-benchmark-app: benchmark-app-common
-
-benchmark-app-clean: benchmark-app-clean-common
-
 ################################################################################
 # Root FS
 ################################################################################
-.PHONY: filelist-tee
-filelist-tee: linux
-filelist-tee: filelist-tee-common
-	@echo "dir /usr/bin 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "dir /boot 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/bcm2710-rpi-3-b.dtb $(LINUX_DTB) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/config.txt $(RPI3_BOOT_CONFIG) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/Image $(LINUX_IMAGE) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/optee.bin $(ARM_TF_BOOT) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/uboot.env $(RPI3_UBOOT_ENV) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/u-boot-rpi.bin $(U-BOOT_RPI_BIN) 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@cd $(MODULE_OUTPUT) && find ! -path . -type d | sed 's/\.\(.*\)/dir \1 755 0 0/g' >> $(GEN_ROOTFS_FILELIST)
-	@cd $(MODULE_OUTPUT) && find -type f | sed "s|\.\(.*\)|file \1 $(MODULE_OUTPUT)\1 755 0 0|g" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/bootcode.bin $(RPI3_STOCK_FW_PATH)/boot/bootcode.bin 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/COPYING.linux $(RPI3_STOCK_FW_PATH)/boot/COPYING.linux 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/fixup_cd.dat $(RPI3_STOCK_FW_PATH)/boot/fixup_cd.dat 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/fixup.dat $(RPI3_STOCK_FW_PATH)/boot/fixup.dat 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/fixup_db.dat $(RPI3_STOCK_FW_PATH)/boot/fixup_db.dat 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/fixup_x.dat $(RPI3_STOCK_FW_PATH)/boot/fixup_x.dat 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/LICENCE.broadcom $(RPI3_STOCK_FW_PATH)/boot/LICENCE.broadcom 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/start_cd.elf $(RPI3_STOCK_FW_PATH)/boot/start_cd.elf 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/start_db.elf $(RPI3_STOCK_FW_PATH)/boot/start_db.elf 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/start.elf $(RPI3_STOCK_FW_PATH)/boot/start.elf 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-	@echo "file /boot/start_x.elf $(RPI3_STOCK_FW_PATH)/boot/start_x.elf 755 0 0" >> $(GEN_ROOTFS_FILELIST)
-
 .PHONY: update_rootfs
-update_rootfs: arm-tf u-boot
-update_rootfs: update_rootfs-common
+# Make sure this is built before the buildroot target which will create the
+# root file system based on what's in $(BUILDROOT_TARGET_ROOT)
+buildroot: update_rootfs
+update_rootfs: arm-tf linux u-boot
+	@mkdir -p --mode=755 $(BUILDROOT_TARGET_ROOT)/boot
+	@mkdir -p --mode=755 $(BUILDROOT_TARGET_ROOT)/usr/bin
+	@install -v -p --mode=755 $(LINUX_DTB) $(BUILDROOT_TARGET_ROOT)/boot/bcm2710-rpi-3-b.dtb
+	@install -v -p --mode=755 $(RPI3_BOOT_CONFIG) $(BUILDROOT_TARGET_ROOT)/boot/config.txt
+	@install -v -p --mode=755 $(LINUX_IMAGE) $(BUILDROOT_TARGET_ROOT)/boot/Image
+	@install -v -p --mode=755 $(ARM_TF_BOOT) $(BUILDROOT_TARGET_ROOT)/boot/optee.bin
+	@install -v -p --mode=755 $(RPI3_UBOOT_ENV) $(BUILDROOT_TARGET_ROOT)/boot/uboot.env
+	@install -v -p --mode=755 $(U-BOOT_RPI_BIN) $(BUILDROOT_TARGET_ROOT)/boot/u-boot-rpi.bin
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/bootcode.bin $(BUILDROOT_TARGET_ROOT)/boot/bootcode.bin
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/COPYING.linux $(BUILDROOT_TARGET_ROOT)/boot/COPYING.linux
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/fixup_cd.dat $(BUILDROOT_TARGET_ROOT)/boot/fixup_cd.dat
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/fixup.dat $(BUILDROOT_TARGET_ROOT)/boot/fixup.dat
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/fixup_db.dat $(BUILDROOT_TARGET_ROOT)/boot/fixup_db.dat
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/fixup_x.dat $(BUILDROOT_TARGET_ROOT)/boot/fixup_x.dat
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/LICENCE.broadcom $(BUILDROOT_TARGET_ROOT)/boot/LICENCE.broadcom
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/start_cd.elf $(BUILDROOT_TARGET_ROOT)/boot/start_cd.elf
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/start_db.elf $(BUILDROOT_TARGET_ROOT)/boot/start_db.elf
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/start.elf $(BUILDROOT_TARGET_ROOT)/boot/start.elf
+	@install -v -p --mode=755 $(RPI3_STOCK_FW_PATH)/boot/start_x.elf $(BUILDROOT_TARGET_ROOT)/boot/start_x.elf
+	@cd $(MODULE_OUTPUT) && find . | cpio -pudm $(BUILDROOT_TARGET_ROOT)
 
 # Creating images etc, could wipe out a drive on the system, therefore we don't
 # want to automate that in script or make target. Instead we just simply provide
@@ -250,7 +215,7 @@ img-help:
 	@echo "   $$ mkdir -p /media/boot"
 	@echo "   $$ mount /dev/sdx1 /media/boot"
 	@echo "   $$ cd /media"
-	@echo "   $$ gunzip -cd $(GEN_ROOTFS_PATH)/filesystem.cpio.gz | sudo cpio -idmv \"boot/*\""
+	@echo "   $$ gunzip -cd $(ROOT)/out-br/images/rootfs.cpio.gz | sudo cpio -idmv \"boot/*\""
 	@echo "   $$ umount boot"
 	@echo ""
 	@echo "run the following as root"
@@ -258,6 +223,6 @@ img-help:
 	@echo "   $$ mkdir -p /media/rootfs"
 	@echo "   $$ mount /dev/sdx2 /media/rootfs"
 	@echo "   $$ cd rootfs"
-	@echo "   $$ gunzip -cd $(GEN_ROOTFS_PATH)/filesystem.cpio.gz | sudo cpio -idmv"
+	@echo "   $$ gunzip -cd $(ROOT)/out-br/images/rootfs.cpio.gz | sudo cpio -idmv"
 	@echo "   $$ rm -rf /media/rootfs/boot/*"
 	@echo "   $$ cd .. && umount rootfs"


### PR DESCRIPTION
Depends on https://github.com/OP-TEE/manifest/pull/116.

```bash
U-Boot 2016.03-00725-gbc6d93cf5e (Jun 11 2018 - 21:07:15 +0200)
...
I/TC:  OP-TEE version: 3.1.0-141-ga0a7d92c #1 Mon Jun 11 19:07:19 UTC 2018 aarch64
...
[    0.000000] Linux version 4.6.3-01139-g7d976fc52ae3 (jbech@debby) (gcc version 6.2.1 20161016 (Linaro GCC 6.2-2016.11) ) #1 SMP Mon Jun 11 21:16:51 CEST 2018
...
buildroot login: root
# xtest
...
+-----------------------------------------------------
16055 subtests of which 0 failed
74 test cases of which 0 failed
0 test case was skipped
TEE test application done!
# 
