### PR TITLE
hikey960: update name of recovery files (hisi-*)

### DIFF
--- a/hikey960.mk
+++ b/hikey960.mk
@@ -282,8 +282,8 @@ endef
 
 .PHONY: recov_cfg
 recov_cfg:
-	@echo "./sec_usb_xloader.img 0x00020000" > $(IMAGE_TOOLS_CONFIG)
-	@echo "./sec_uce_boot.img 0x6A908000" >> $(IMAGE_TOOLS_CONFIG)
+	@echo "./hisi-sec_usb_xloader.img 0x00020000" > $(IMAGE_TOOLS_CONFIG)
+	@echo "./hisi-sec_uce_boot.img 0x6A908000" >> $(IMAGE_TOOLS_CONFIG)
 	@echo "./recovery.bin 0x1AC00000" >> $(IMAGE_TOOLS_CONFIG)
 
 .PHONY: recovery


### PR DESCRIPTION
The files used by "make recovery" have been renamed [1].
   
Link: [1] https://github.com/96boards-hikey/tools-images-hikey960/commit/b5ae2c13438e
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
