### PR TITLE
grub: ignore harmless warning

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -127,7 +127,8 @@ grub-flags := CC="$(CCACHE)gcc" \
 	TARGET_OBJCOPY="$(AARCH64_CROSS_COMPILE)objcopy" \
 	TARGET_NM="$(AARCH64_CROSS_COMPILE)nm" \
 	TARGET_RANLIB="$(AARCH64_CROSS_COMPILE)ranlib" \
-	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip"
+	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip" \
+	--disable-werror
 
 GRUB_MODULES += boot chain configfile echo efinet eval ext2 fat font gettext \
 		gfxterm gzio help linux loadenv lsefi normal part_gpt \

--- a/hikey.mk
+++ b/hikey.mk
@@ -202,7 +202,8 @@ grub-flags := CC="$(CCACHE)gcc" \
 	TARGET_OBJCOPY="$(AARCH64_CROSS_COMPILE)objcopy" \
 	TARGET_NM="$(AARCH64_CROSS_COMPILE)nm" \
 	TARGET_RANLIB="$(AARCH64_CROSS_COMPILE)ranlib" \
-	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip"
+	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip" \
+	--disable-werror
 
 GRUB_MODULES += boot chain configfile efinet ext2 fat gettext \
                 help linux loadenv lsefi normal part_gpt \

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -195,7 +195,8 @@ grub-flags := CC="$(CCACHE)gcc" \
 	TARGET_OBJCOPY="$(AARCH64_CROSS_COMPILE)objcopy" \
 	TARGET_NM="$(AARCH64_CROSS_COMPILE)nm" \
 	TARGET_RANLIB="$(AARCH64_CROSS_COMPILE)ranlib" \
-	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip"
+	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip" \
+	--disable-werror
 
 GRUB_MODULES += boot chain configfile echo efinet eval ext2 fat font gettext \
                 gfxterm gzio help linux loadenv lsefi normal part_gpt \

--- a/hikey_debian.mk
+++ b/hikey_debian.mk
@@ -254,7 +254,8 @@ grub-flags := CC="$(CCACHE)gcc" \
 	TARGET_OBJCOPY="$(AARCH64_CROSS_COMPILE)objcopy" \
 	TARGET_NM="$(AARCH64_CROSS_COMPILE)nm" \
 	TARGET_RANLIB="$(AARCH64_CROSS_COMPILE)ranlib" \
-	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip"
+	TARGET_STRIP="$(AARCH64_CROSS_COMPILE)strip" \
+	--disable-werror
 
 GRUB_MODULES += boot chain configfile echo efinet eval ext2 fat font gettext \
 		gfxterm gzio help linux loadenv lsefi normal part_gpt \


### PR DESCRIPTION
Grub 2.02 has a harmless warning with recent GCC compilers. Avoid the
problem by configuring Grub with --disable-werror.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>