### PR TITLE
qemu: doc: fix host folder sharing documentation

### DIFF
--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -43,7 +43,7 @@ rebuild QEMU.
 To mount host folder in QEMU, simply run:
 
 ```bash
-$ mount_shared <mount_point>
+$ mount -t 9p -o trans=virtio host <mount_point>
 ```
 # 5. SLiRP user networking
 To enable SLiRP user networking just set `QEMU_USERNET_ENABLE ?= y` in `common.mk`.


### PR DESCRIPTION
Now that buildroot is used, the 'mount_shared' alias is not available
anymore. Document the full command instead.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>