### PR TITLE
qemu: buildroot: fix networking

### DIFF
--- a/br-ext/board/qemu/overlay/etc/init.d/S50udhcpc
+++ b/br-ext/board/qemu/overlay/etc/init.d/S50udhcpc
@@ -1,0 +1,23 @@
+#!/bin/sh
+case "$1" in
+  start)
+	printf "Starting network (udhcpc): "
+	udhcpc >> /var/log/udhcpc.log 2>&1
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	;;
+  stop)
+	printf "Stopping network (udhcpc): "
+	killall udhcpc
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	;;
+  restart|reload)
+	"$0" stop
+	"$0" start
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?
+

--- a/common.mk
+++ b/common.mk
@@ -201,6 +201,8 @@ buildroot: optee-os
 	@touch ../out-br/extra.conf
 	@echo "BR2_TARGET_GENERIC_GETTY_PORT=\"$(BUILDROOT_GETTY_PORT)\"" >> \
 		../out-br/extra.conf
+	@echo "BR2_ROOTFS_OVERLAY=\"$(ROOT)/build/br-ext/board/qemu/overlay\"" >> \
+		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \
 		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \


### PR DESCRIPTION
Adds the missing startup file to the buildroot-generated filesystem so
that networking is available in the VM as claimed by docs/qemu.md.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>