### PR TITLE
buildroot: tee-supplicant: use -d (daemonize) option and print OK/FAIL

### DIFF
--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -7,9 +7,9 @@
 case "$1" in
     start)
 	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
-		echo "Starting tee-supplicant..."
-		/usr/sbin/tee-supplicant &
-		exit 0
+		printf "Starting tee-supplicant... "
+		/usr/sbin/tee-supplicant -d
+		[ $? = 0 ] && echo "OK" || echo "FAIL"
 	else
 		echo "tee-supplicant or TEE device not found"
 		exit 1


### PR DESCRIPTION
Init scripts normally print OK or FAIL when they start daemons. Update
our tee-supplicant script to do just that. The -d option to tee-supplicant
is used so that when the tee-supplicant command returns, we  know for sure
if initialization went well or not.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>