### PR TITLE
buildroot: run tee-supplicant as non-root

### DIFF
--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -7,8 +7,14 @@
 case "$1" in
     start)
 	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
+		# tee-supplicant and the client applications need not run as
+		# root provided that the TEE devices and the data store have
+		# proper permissions
+		printf "Setting permissions on /dev/tee*... "
+		chown root:tee /dev/tee* && chmod 0660 /dev/tee*
+		[ $? = 0 ] && echo "OK" || echo "FAIL"
 		printf "Starting tee-supplicant... "
-		/usr/sbin/tee-supplicant -d
+		su tee -c '/usr/sbin/tee-supplicant -d'
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
 	else
 		echo "tee-supplicant or TEE device not found"

--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -7,9 +7,9 @@
 case "$1" in
     start)
 	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
-		echo "Starting tee-supplicant..."
-		/usr/sbin/tee-supplicant &
-		exit 0
+		printf "Starting tee-supplicant... "
+		/usr/sbin/tee-supplicant -d
+		[ $? = 0 ] && echo "OK" || echo "FAIL"
 	else
 		echo "tee-supplicant or TEE device not found"
 		exit 1

--- a/br-ext/package/optee_client/optee_client.mk
+++ b/br-ext/package/optee_client/optee_client.mk
@@ -17,4 +17,13 @@ define OPTEE_CLIENT_INSTALL_INIT_SYSV
 	$(OPTEE_CLIENT_INSTALL_SUPPLICANT_SCRIPT)
 endef
 
+define OPTEE_CLIENT_USERS
+	tee -1 tee -1 * - /bin/sh - TEE user
+endef
+
+define OPTEE_CLIENT_PERMISSIONS
+	/data d 755 root root - - - - -
+	/data/tee d 770 tee tee - - - - -
+endef
+
 $(eval $(cmake-package))


### PR DESCRIPTION
Note: first commit is https://github.com/OP-TEE/build/pull/290.

Updates so that `tee-supplicant` and `xtest` may be run as a non-root user.