### PR TITLE
buildroot: add teeclnt group and test user account

### DIFF
--- a/br-ext/configs/optee_generic
+++ b/br-ext/configs/optee_generic
@@ -1,5 +1,5 @@
 BR2_CCACHE=y
-BR2_TARGET_GENERIC_ISSUE="Welcome to Buildroot, type root to login"
+BR2_TARGET_GENERIC_ISSUE="Welcome to Buildroot, type root or test to login"
 
 BR2_TARGET_ROOTFS_CPIO=y
 BR2_TARGET_ROOTFS_CPIO_GZIP=y

--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -11,7 +11,8 @@ case "$1" in
 		# root provided that the TEE devices and the data store have
 		# proper permissions
 		printf "Setting permissions on /dev/tee*... "
-		chown root:tee /dev/tee* && chmod 0660 /dev/tee*
+		chown root:tee /dev/teepriv0 && chmod 0660 /dev/teepriv0 && \
+			chown root:teeclnt /dev/tee0 && chmod 0660 /dev/tee0
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
 		printf "Starting tee-supplicant... "
 		su tee -c '/usr/sbin/tee-supplicant -d'

--- a/br-ext/package/optee_client/optee_client.mk
+++ b/br-ext/package/optee_client/optee_client.mk
@@ -17,8 +17,13 @@ define OPTEE_CLIENT_INSTALL_INIT_SYSV
 	$(OPTEE_CLIENT_INSTALL_SUPPLICANT_SCRIPT)
 endef
 
+# User tee is used to run tee-supplicant because access to /dev/teepriv0 is
+# restricted to group tee.
+# Any user in group teeclnt (such as test) may run client applications.
 define OPTEE_CLIENT_USERS
 	tee -1 tee -1 * - /bin/sh - TEE user
+	- -1 teeclnt -1 - - - - TEE users group
+	test -1 test -1 - - /bin/sh teeclnt Test user, may run TEE client applications
 endef
 
 define OPTEE_CLIENT_PERMISSIONS


### PR DESCRIPTION
Restrict execution of TEE client applications to members of the teeclnt
group. A test user is created and added to this group.
Having two groups (tee and teeclnt) allows to better isolate
tee-supplicant from the client applications.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>