### PR TITLE
fvp: use DT file foundation-v8-gicv3-psci.dtb

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -167,7 +167,7 @@ boot-img: linux grub buildroot
 	rm -f $(BOOT_IMG)
 	mformat -i $(BOOT_IMG) -n 64 -h 255 -T 131072 -v "BOOT IMG" -C ::
 	mcopy -i $(BOOT_IMG) $(LINUX_PATH)/arch/arm64/boot/Image ::
-	mcopy -i $(BOOT_IMG) $(LINUX_PATH)/arch/arm64/boot/dts/arm/foundation-v8.dtb ::
+	mcopy -i $(BOOT_IMG) $(LINUX_PATH)/arch/arm64/boot/dts/arm/foundation-v8-gicv3-psci.dtb ::
 	mmd -i $(BOOT_IMG) ::/EFI
 	mmd -i $(BOOT_IMG) ::/EFI/BOOT
 	mcopy -i $(BOOT_IMG) $(ROOT)/out-br/images/rootfs.cpio.gz ::/initrd.img

--- a/fvp/grub/grub.cfg
+++ b/fvp/grub/grub.cfg
@@ -6,5 +6,5 @@ set timeout=10
 menuentry 'GNU/Linux (OP-TEE)' {
     linux /Image console=tty0 console=ttyAMA0,115200 earlycon=pl011,0x1c090000 root=/dev/disk/by-partlabel/system rootwait rw ignore_loglevel efi=noruntime
     initrd /initrd.img
-    devicetree /foundation-v8.dtb
+    devicetree /foundation-v8-gicv3-psci.dtb
 }


### PR DESCRIPTION
The Device Tree configuration we need for the Foundation Platform is now
available upstream (v4.18) as foundation-v8-gicv3-psci.dts (it only lacks
the optee node and memory reservations). Let's use this new file instead
of a hacked version of foundation-v8.dts modified for PSCI and GiCv3.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>