### PR TITLE
buildroot: optee_client: add ion group and set permissions on /dev/ion

### DIFF
--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -14,6 +14,11 @@ case "$1" in
 		chown root:tee /dev/teepriv0 && chmod 0660 /dev/teepriv0 && \
 			chown root:teeclnt /dev/tee0 && chmod 0660 /dev/tee0
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
+		if [ -e /dev/ion ]; then
+			printf "Setting permissions on /dev/ion... "
+			chown root:ion /dev/ion && chmod 0660 /dev/ion
+			[ $? = 0 ] && echo "OK" || echo "FAIL"
+		fi
 		printf "Starting tee-supplicant... "
 		su tee -c '/usr/sbin/tee-supplicant -d'
 		[ $? = 0 ] && echo "OK" || echo "FAIL"

--- a/br-ext/package/optee_client/optee_client.mk
+++ b/br-ext/package/optee_client/optee_client.mk
@@ -20,10 +20,12 @@ endef
 # User tee is used to run tee-supplicant because access to /dev/teepriv0 is
 # restricted to group tee.
 # Any user in group teeclnt (such as test) may run client applications.
+# Any user in group ion may access /dev/ion
 define OPTEE_CLIENT_USERS
 	tee -1 tee -1 * - /bin/sh - TEE user
 	- -1 teeclnt -1 - - - - TEE users group
-	test -1 test -1 - - /bin/sh teeclnt Test user, may run TEE client applications
+	- -1 ion -1 - - - - ION users group
+	test -1 test -1 - - /bin/sh teeclnt,ion Test user, may run TEE client applications
 endef
 
 define OPTEE_CLIENT_PERMISSIONS


### PR DESCRIPTION
If /dev/ion exists, it should be set up so that the test user can access
it. Otherwise, some tests will fail, such as xtest 1014 (Secure Data
Path). Similar to what is done for /dev/tee*, this commit configures
permissions based on a specific group: ion.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>