### PR TITLE
qemu, qemu_v8: set QEMU_SMP ?= 2

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -167,7 +167,7 @@ run: all
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(MAKE) run-only
 
-QEMU_SMP ?= 1
+QEMU_SMP ?= 2
 
 .PHONY: run-only
 run-only:

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -154,7 +154,7 @@ soc-term-clean:
 run: all
 	$(MAKE) run-only
 
-QEMU_SMP ?= 1
+QEMU_SMP ?= 2
 
 .PHONY: run-only
 run-only:


### PR DESCRIPTION
Use two vCPUs by default instead of one. This configuration is more
likely to trigger race conditions when testing.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>