### PR TITLE
buildroot: use QEMU overlay only when platform is QEMU or QEMUv8

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -204,8 +204,9 @@ buildroot: optee-os
 	@touch ../out-br/extra.conf
 	@echo "BR2_TARGET_GENERIC_GETTY_PORT=\"$(BUILDROOT_GETTY_PORT)\"" >> \
 		../out-br/extra.conf
-	@echo "BR2_ROOTFS_OVERLAY=\"$(ROOT)/build/br-ext/board/qemu/overlay\"" >> \
-		../out-br/extra.conf
+ifneq (,$(BR2_ROOTFS_OVERLAY))
+	@echo "BR2_ROOTFS_OVERLAY=\"$(BR2_ROOTFS_OVERLAY)\"" >> ../out-br/extra.conf
+endif
 	@echo "BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \
 		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \

--- a/qemu.mk
+++ b/qemu.mk
@@ -8,6 +8,8 @@ override COMPILE_NS_KERNEL := 32
 override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
+BR2_ROOTFS_OVERLAY = $(ROOT)/build/br-ext/board/qemu/overlay
+
 include common.mk
 
 ################################################################################

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -8,6 +8,8 @@ override COMPILE_NS_KERNEL := 64
 override COMPILE_S_USER    := 64
 override COMPILE_S_KERNEL  := 64
 
+BR2_ROOTFS_OVERLAY = $(ROOT)/build/br-ext/board/qemu/overlay
+
 include common.mk
 
 ################################################################################


### PR DESCRIPTION
common.mk mistakenly uses the QEMU overlay (which currently contains
only an init script for udhcpc) on all platforms. This is incorrect and
causes problems on RPi3 at least [1].

Fixes: commit 751b35bb0b84 ("qemu: buildroot: fix networking")
Links: [1] https://github.com/OP-TEE/optee_os/issues/2478#issuecomment-432818199
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>