### PR TITLE
fvp: use GICv3 to support TF-A v2.0

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -59,7 +59,7 @@ ARM_TF_FLAGS ?= \
 	BL33=$(EDK2_BIN) \
 	DEBUG=0 \
 	ARM_TSP_RAM_LOCATION=tdram \
-	FVP_USE_GIC_DRIVER=FVP_GICV3_LEGACY \
+	FVP_USE_GIC_DRIVER=FVP_GICV3 \
 	PLAT=fvp \
 	SPD=opteed
 
@@ -113,7 +113,7 @@ linux-cleaner: linux-cleaner-common
 ################################################################################
 # OP-TEE
 ################################################################################
-OPTEE_OS_COMMON_FLAGS += PLATFORM=vexpress-fvp
+OPTEE_OS_COMMON_FLAGS += PLATFORM=vexpress-fvp CFG_ARM_GICV3=y
 optee-os: optee-os-common
 
 OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=vexpress-fvp


### PR DESCRIPTION
Adds support for Arm Trusted Firmware-A version v2.0.

TF-A v2.0 does not acccept FVP_USE_GIC_DRIVER=FVP_GICV3_LEGACY anymore.
Therefore, use FVP_GICV3 instead. This is the default value with v2.0, and
is also supported by earlier versions (such as 1.5 which is the one we are
using currently).

OP-TEE is configured accordingly (CFG_ARM_GICV3=y).

~~** Note ** Depends on an optee_os patch, see PR 2548.~~ That was PR 2560, merged.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>