### PR TITLE
rpi3: spawn getty for both HDMI and serial console

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -207,6 +207,10 @@ buildroot: optee-os
 ifneq (,$(BR2_ROOTFS_OVERLAY))
 	@echo "BR2_ROOTFS_OVERLAY=\"$(BR2_ROOTFS_OVERLAY)\"" >> ../out-br/extra.conf
 endif
+ifneq (,$(BR2_ROOTFS_POST_BUILD_SCRIPT))
+	@echo "BR2_ROOTFS_POST_BUILD_SCRIPT=\"$(BR2_ROOTFS_POST_BUILD_SCRIPT)\"" >> \
+		../out-br/extra.conf
+endif
 	@echo "BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \
 		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \

--- a/rpi3.mk
+++ b/rpi3.mk
@@ -10,6 +10,7 @@ override COMPILE_S_KERNEL  := 64
 
 # Need to set this before including common.mk
 BUILDROOT_GETTY_PORT ?= ttyS0
+BR2_ROOTFS_POST_BUILD_SCRIPT ?= "board/raspberrypi3-64/post-build.sh"
 
 include common.mk
 


### PR DESCRIPTION
Spawn getty for both HDMI and serial console. Leverage
post-build.sh script for rpi3, which adds getty line for
tty1 in inittab [1].

[1]: https://patchwork.ozlabs.org/patch/602668/

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`