### PR TITLE
Update the launch_terminal definition in case of using LAUNCH_TERMINAL

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -336,10 +336,12 @@ define run-help
 	@echo
 endef
 
+# Note: Using the LAUNCH_TERMINAL environment variable, it is not currently possible to set 
+# different titles for the terminals because there is no any common way among all the terminals
 ifneq (, $(LAUNCH_TERMINAL))
 define launch-terminal
 	@nc -z  127.0.0.1 $(1) || \
-		$(LAUNCH_TERMINAL) $(SOC_TERM_PATH)/soc_term $(1) &
+		$(LAUNCH_TERMINAL) "$(SOC_TERM_PATH)/soc_term $(1)" &
 endef
 else
 gnome-terminal := $(shell command -v gnome-terminal 2>/dev/null)


### PR DESCRIPTION
Add quotes around the soc_term and the port number to make it compatible with other terminals like terminator.

To use terminator it is enough to set the flag like:
$ export LAUNCH_TERMINAL="terminator -e"
$ make run-only

Note in this case the title of the terminals cannot be set properly

Signed-off-by: Hashem Tatari <hashem.tatari@exset.com>