### PR TITLE
rpi3: update OpenOCD configuration for RPi3

### DIFF
--- a/rpi3/debugger/pi3.cfg
+++ b/rpi3/debugger/pi3.cfg
@@ -1,38 +1,47 @@
-#  RPi3b
-
-tcl_port 5555
-telnet_port 4444
-gdb_port 3333
-
+# Credits to Petr Tesarik from SUSE who provided this updated configuration,
+# source: https://www.suse.com/c/debugging-raspberry-pi-3-with-jtag/
 transport select jtag
 
+# we need to enable srst even though we don't connect it
+reset_config trst_and_srst
+
 adapter_khz 1000
+jtag_ntrst_delay 500
 
-jtag_ntrst_delay 100
-reset_config trst_only separate 
-
-set _CHIPNAME rpi3b
-
-set _TARGETNAME_0 $_CHIPNAME.cpu0
-set _TARGETNAME_1 $_CHIPNAME.cpu1
-set _TARGETNAME_2 $_CHIPNAME.cpu2
-set _TARGETNAME_3 $_CHIPNAME.cpu3
-
-jtag newtap $_CHIPNAME dap -irlen 4 -expected-id 0x4ba00477
-
-target create $_TARGETNAME_0 aarch64 -chain-position $_CHIPNAME.dap -dbgbase 0x80010000 -ctibase 0x80018000
-#target create $_TARGETNAME_1 aarch64 -chain-position $_CHIPNAME.dap -dbgbase 0x80012000 -ctibase 0x80019000
-#target create $_TARGETNAME_2 aarch64 -chain-position $_CHIPNAME.dap -dbgbase 0x80014000 -ctibase 0x8001a000
-#target create $_TARGETNAME_3 aarch64 -chain-position $_CHIPNAME.dap -dbgbase 0x80016000 -ctibase 0x8001b000
-
-#target smp $_CHIPNAME.cpu3 $_CHIPNAME.cpu2 $_CHIPNAME.cpu1 $_CHIPNAME.cpu0
-
-proc rpi3b_gdb_attach {target} {
-  echo "gdb attach halt ..."
-  targets 0
-  halt
+if { [info exists CHIPNAME] } {
+  set _CHIPNAME $CHIPNAME
+} else {
+  set _CHIPNAME rpi3
 }
 
-$_TARGETNAME_0 configure -event gdb-attach {
-  halt
+#
+# Main DAP
+#
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x4ba00477
+}
+
+jtag newtap $_CHIPNAME tap -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_DAP_TAPID -enable
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.tap
+
+set _TARGETNAME $_CHIPNAME.a53
+set _CTINAME $_CHIPNAME.cti
+
+set DBGBASE {0x80010000 0x80012000 0x80014000 0x80016000}
+set CTIBASE {0x80018000 0x80019000 0x8001a000 0x8001b000}
+set _cores 4
+
+for { set _core 0 } { $_core < $_cores } { incr _core } {
+
+    cti create $_CTINAME.$_core -dap $_CHIPNAME.dap -ap-num 0 \
+        -ctibase [lindex $CTIBASE $_core]
+
+    target create $_TARGETNAME.$_core aarch64 \
+        -dap $_CHIPNAME.dap -coreid $_core \
+        -dbgbase [lindex $DBGBASE $_core] -cti $_CTINAME.$_core
+
+    $_TARGETNAME.$_core configure -event reset-assert-post "aarch64 dbginit"
+    $_TARGETNAME.$_core configure -event gdb-attach { halt }
 }


### PR DESCRIPTION
While doing updates to [the upcoming optee_docs / RPi3](https://optee.readthedocs.io/building/devices/rpi3.html#jtag), I've tested JTAG at the same time and found out that there was indeed an issue with the pi3.cfg file. I found another config that makes it working again and now it seems like having all 4 cores enabled also behaves nicely.

Fixes an old issue also (already closed): https://github.com/OP-TEE/build/issues/257
