### PR TITLE
optee service: update tee-supplicant install path

### DIFF
--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -6,7 +6,7 @@
 #
 case "$1" in
     start)
-	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
+	if [ -e /usr/bin/tee-supplicant -a -e /dev/teepriv0 ]; then
 		# tee-supplicant and the client applications need not run as
 		# root provided that the TEE devices and the data store have
 		# proper permissions
@@ -24,7 +24,7 @@ case "$1" in
 			chmod 0770 /data/tee
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
 		printf "Starting tee-supplicant... "
-		su tee -c '/usr/sbin/tee-supplicant -d'
+		su tee -c '/usr/bin/tee-supplicant -d'
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
 	else
 		echo "tee-supplicant or TEE device not found"


### PR DESCRIPTION
tee-supplicant is installed in /usr/bin instead of /usr/sbin.

This change depends on https://github.com/OP-TEE/optee_client/pull/142.