### PR TITLE
[RFC] optee services: update script

### DIFF
--- a/br-ext/package/optee_client/S30optee
+++ b/br-ext/package/optee_client/S30optee
@@ -1,42 +1,82 @@
 #!/bin/sh
-#
-# /etc/init.d/optee
-#
-# Start/stop tee-supplicant (OP-TEE normal world daemon)
-#
-case "$1" in
-    start)
-	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
-		# tee-supplicant and the client applications need not run as
-		# root provided that the TEE devices and the data store have
-		# proper permissions
-		printf "Setting permissions on /dev/tee*... "
-		chown root:tee /dev/teepriv0 && chmod 0660 /dev/teepriv0 && \
-			chown root:teeclnt /dev/tee0 && chmod 0660 /dev/tee0
-		[ $? = 0 ] && echo "OK" || echo "FAIL"
-		if [ -e /dev/ion ]; then
-			printf "Setting permissions on /dev/ion... "
-			chown root:ion /dev/ion && chmod 0660 /dev/ion
-			[ $? = 0 ] && echo "OK" || echo "FAIL"
-		fi
-		printf "Create and set permissions on /data... "
-		mkdir -p /data/tee && chown -R tee:tee /data/tee && \
-			chmod 0770 /data/tee
-		[ $? = 0 ] && echo "OK" || echo "FAIL"
-		printf "Starting tee-supplicant... "
-		su tee -c '/usr/sbin/tee-supplicant -d'
-		[ $? = 0 ] && echo "OK" || echo "FAIL"
-	else
-		echo "tee-supplicant or TEE device not found"
-		exit 1
-	fi
 
-        ;;
-    stop)
-	killall tee-supplicant
-	;;
-    status)
-	cat /dev/teepriv0 2>&1 | grep -q "Device or resource busy" || not="not "
-	echo "tee-supplicant is ${not}active"
-	;;
+DAEMON="tee-supplicant"
+DAEMON_PATH="/usr/sbin"
+DAEMON_ARGS="-d /dev/teepriv0"
+PIDFILE="/var/run/$DAEMON.pid"
+
+start() {
+	# tee-supplicant and the client applications need not run as
+	# root provided that the TEE devices and the data store have
+	# proper permissions
+	printf 'Set permissions on %s: ' "/dev/tee*"
+	chown root:tee /dev/teepriv0 && chmod 0660 /dev/teepriv0 && \
+		chown root:teeclnt /dev/tee0 && chmod 0660 /dev/tee0
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+		return "$status"
+	fi
+	if [ -e /dev/ion ]; then
+		printf 'Set permissions on %s: ' "/dev/ion"
+		chown root:ion /dev/ion && chmod 0660 /dev/ion
+		status=$?
+		if [ "$status" -eq 0 ]; then
+			echo "OK"
+		else
+			echo "FAIL"
+			return "$status"
+		fi
+	fi
+	printf 'Create/set permissions on %s: ' "/data/tee"
+	mkdir -p /data/tee && chown -R tee:tee /data/tee && chmod 0770 /data/tee
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+		return "$status"
+	fi
+	printf 'Starting %s: ' "$DAEMON"
+	start-stop-daemon -S -q -p "$PIDFILE" -c tee -x "$DAEMON_PATH/$DAEMON" \
+		-- $DAEMON_ARGS
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+stop() {
+	printf 'Stopping %s: ' "$DAEMON"
+	start-stop-daemon -K -q -p "$PIDFILE"
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+restart() {
+	stop
+	sleep 1
+	start
+}
+
+case "$1" in
+        start|stop|restart)
+		"$1";;
+	reload)
+		# Restart, since there is no true "reload" feature (does not
+		# reconfigure/restart on SIGHUP, just closes all open files).
+		restart;;
+        *)
+                echo "Usage: $0 {start|stop|restart|reload}"
+                exit 1
 esac


### PR DESCRIPTION
Update script based on the feedback from Buildroot maintainer [1]:

>  > \+# /etc/init.d/optee
> 
>  Drop this comment, it is useless, and in fact wrong: the file will not
>  have this name in a Buildroot filesystem.
>
> (...)
> > \+	if [ -e /usr/sbin/tee-supplicant -a -e /dev/teepriv0 ]; then
>
> Drop this test, just start tee-supplicatn.
> (...)
> > \+		echo "Starting tee-supplicant..."
> > \+		/usr/sbin/tee-supplicant &
>
> Please use start-stop-daemon. See
> https://patchwork.ozlabs.org/patch/994013/ for the "right" way of
> writing an init script.

This maybe not be best way, if there's one, but it seems more
standard to use start-stop-daemon. Moreover the proposed script
ensures its return value matches the status of the caller request.

Note that I preserved the **status** case which Buildroot does not want.

[1] http://lists.busybox.net/pipermail/buildroot/2018-December/238354.html