### PR TITLE
Add support for Xilinx zcu102, zcu104 and zcu106 ZynqMP boards

### DIFF
--- a/zynqmp.mk
+++ b/zynqmp.mk
@@ -1,0 +1,63 @@
+ROOT			= $(PWD)/..
+PLATFORM		?= zcu102
+PETALINUX_PATH		?= /opt/Xilinx/petalinx_2018_2
+BSP_PATH		?= ./xilinx-${PLATFORM}-v2018.2-final.bsp
+PRJ_PATH		?= $(ROOT)/xilinx-${PLATFORM}-2018.2
+PETALINUX_CFG_PATH	?= $(ROOT)/build/zynqmp
+OPTEE_VER		?= latest
+
+define set_cfg
+	@sed -i 's/$(1)=.*/$(1)=$(2)/' $(3)
+endef
+
+define set_optee_version
+	@if [ "$(1)" != "latest" ]; then \
+		echo 'OPTEE_VERSION ?= "$(1)"' > $(2); \
+		echo 'SRCREV ?= "$(1)"' >> $(2); \
+	else \
+		echo 'OPTEE_VERSION ?= "latest"' > $(2); \
+		echo 'SRCREV ?= "$${AUTOREV}"' >> $(2); \
+	fi
+endef
+
+.PHONY: check-petalinux
+
+check-petalinux:
+ifndef PETALINUX_VER
+	$(error You have to source Petalinux settings)
+endif
+ifneq ($(PETALINUX_VER),2018.2)
+	$(error This makefile only support Petalinux 2018.2)
+endif
+
+petalinux-create: check-petalinux
+	@cd $(ROOT) && petalinux-create -t project -s $(BSP_PATH)
+	@cd $(PRJ_PATH) && petalinux-create -t apps --template install -n optee-client --enable
+	@cd $(PRJ_PATH) && petalinux-create -t apps --template install -n optee-test --enable
+	@#
+	$(call set_cfg,CONFIG_SUBSYSTEM_ATF_COMPILE_EXTRA_SETTINGS,"SPD=opteed ZYNQMP_BL32_MEM_BASE=0x60000000 ZYNQMP_BL32_MEM_SIZE=0x80000",$(PRJ_PATH)/project-spec/configs/config)
+	$(call set_cfg,CONFIG_SUBSYSTEM_ZYNQMP_ATF_MEM_SIZE,0x16001,$(PRJ_PATH)/project-spec/configs/config)
+	@#
+	@cp $(PETALINUX_CFG_PATH)/kernel_optee.cfg $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx/
+	@cp $(PETALINUX_CFG_PATH)/linux-xlnx_%.bbappend $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
+	@cp $(PETALINUX_CFG_PATH)/system-user.dtsi $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/device-tree/files/
+	@#
+	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/arm-trusted-firmware/
+	@cp -r $(PETALINUX_CFG_PATH)/arm-trusted-firmware/* $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/arm-trusted-firmware/
+	@#
+	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os
+	@cp -r $(PETALINUX_CFG_PATH)/optee-os/* $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os/
+	@cp -r $(PETALINUX_CFG_PATH)/optee-client/* $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/
+	@cp -r $(PETALINUX_CFG_PATH)/optee-test/* $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/
+	
+petalinux-config:
+	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/optee-test.bbappend)
+	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/optee-client.bbappend)
+	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os/optee-os.bbappend)
+	@cd $(PRJ_PATH) && petalinux-config --oldconfig
+
+petalinux-build:
+	@cd $(PRJ_PATH) && petalinux-build
+	
+qemu:
+	@cd $(PRJ_PATH) && petalinux-boot --qemu --qemu-args "-device loader,file=${PRJ_PATH}/images/linux/bl32.elf" --kernel

--- a/zynqmp/arm-trusted-firmware/arm-trusted-firmware_2018.2.bb
+++ b/zynqmp/arm-trusted-firmware/arm-trusted-firmware_2018.2.bb
@@ -1,0 +1,71 @@
+ATF_VERSION = "2.0"
+SRCREV ??= "dbc8d9496ead9ecdd7c2a276b542a4fbbbf64027"
+BRANCH ??= "master"
+DESCRIPTION = "Trusted Firmware-A"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://license.rst;md5=e927e02bca647e14efd87e9e914b2443"
+
+PROVIDES = "virtual/arm-trusted-firmware"
+
+inherit deploy
+
+DEPENDS += "u-boot-mkimage-native"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+ATF_VERSION_EXTENSION ?= "-arm"
+PV = "${ATF_VERSION}${ATF_VERSION_EXTENSION}+git${SRCPV}"
+
+BRANCH ??= ""
+REPO ??= "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https"
+BRANCHARG = "${@['nobranch=1', 'branch=${BRANCH}'][d.getVar('BRANCH', True) != '']}"
+SRC_URI = "${REPO};${BRANCHARG}"
+
+ATF_BASE_NAME ?= "${PN}-${PKGE}-${PKGV}-${PKGR}-${DATETIME}"
+ATF_BASE_NAME[vardepsexclude] = "DATETIME"
+
+COMPATIBLE_MACHINE = "zynqmp"
+PLATFORM_zynqmp = "zynqmp"
+
+# requires CROSS_COMPILE set by hand as there is no configure script
+export CROSS_COMPILE="${TARGET_PREFIX}"
+
+# Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
+CFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+
+ATF_CONSOLE ?= ""
+ATF_CONSOLE_zynqmp = "cadence"
+
+DEBUG ?= ""
+EXTRA_OEMAKE_zynqmp_append = "${@' ZYNQMP_CONSOLE=${ATF_CONSOLE}' if d.getVar('ATF_CONSOLE', True) != '' else ''}"
+EXTRA_OEMAKE_append = " ${@bb.utils.contains('DEBUG', '1', ' DEBUG=${DEBUG}', '', d)}"
+
+OUTPUT_DIR = "${@bb.utils.contains('DEBUG', '1', '${B}/${PLATFORM}/debug', '${B}/${PLATFORM}/release', d)}"
+
+ATF_MEM_BASE ?= ""
+ATF_MEM_SIZE ?= ""
+
+EXTRA_OEMAKE_zynqmp_append = "${@' ZYNQMP_ATF_MEM_BASE=${ATF_MEM_BASE}' if d.getVar('ATF_MEM_BASE', True) != '' else ''}"
+EXTRA_OEMAKE_zynqmp_append = "${@' ZYNQMP_ATF_MEM_SIZE=${ATF_MEM_SIZE}' if d.getVar('ATF_MEM_SIZE', True) != '' else ''}"
+
+do_configure() {
+	oe_runmake clean -C ${S} BUILD_BASE=${B} PLAT=${PLATFORM}
+}
+
+do_compile() {
+	oe_runmake -C ${S} BUILD_BASE=${B} PLAT=${PLATFORM} RESET_TO_BL31=1 bl31
+}
+
+do_deploy() {
+	install -d ${DEPLOYDIR}
+	install -m 0644 ${OUTPUT_DIR}/bl31/bl31.elf ${DEPLOYDIR}/${ATF_BASE_NAME}.elf
+	ln -sf ${ATF_BASE_NAME}.elf ${DEPLOYDIR}/${PN}.elf
+	install -m 0644 ${OUTPUT_DIR}/bl31.bin ${DEPLOYDIR}/${ATF_BASE_NAME}.bin
+	ln -sf ${ATF_BASE_NAME}.bin ${DEPLOYDIR}/${PN}.bin
+}
+addtask deploy before do_build after do_compile

--- a/zynqmp/kernel_optee.cfg
+++ b/zynqmp/kernel_optee.cfg
@@ -1,0 +1,6 @@
+CONFIG_TEE=y
+
+#
+# TEE drivers
+#
+CONFIG_OPTEE=y

--- a/zynqmp/linux-xlnx_%.bbappend
+++ b/zynqmp/linux-xlnx_%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI += "file://bsp.cfg \
+            "
+SRC_URI_append += "file://kernel_optee.cfg"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/zynqmp/optee-client/optee-client.bb
+++ b/zynqmp/optee-client/optee-client.bb
@@ -1,0 +1,36 @@
+OPTEE_VERSION ??= "latest"
+SRCREV ??= "${AUTOREV}"
+BRANCH ??= "master"
+
+DESCRIPTION = "OP-TEE Client"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+PROVIDES = "virtual/optee-client"
+DEPENDS += "virtual/optee-os"
+
+S = "${WORKDIR}/git"
+PV = "${OPTEE_VERSION}+git${SRCPV}"
+
+REPO ??= "git://github.com/OP-TEE/optee_client.git;protocol=https"
+SRC_URI = "${REPO};branch=${BRANCH}"
+
+# requires CROSS_COMPILE set by hand as there is no configure script
+export CROSS_COMPILE="${TARGET_PREFIX}"
+
+EXPORT_DIR = "${TMPDIR}/deploy/images/${MACHINE}/optee/export_client"
+
+EXTRA_OEMAKE_append = " CROSS_COMPILE=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " DESTDIR=${EXPORT_DIR}"
+EXTRA_OEMAKE_append = " SBINDIR=/sbin"
+EXTRA_OEMAKE_append = " LIBDIR=/lib"
+EXTRA_OEMAKE_append = " INCLUDEDIR=/include"
+
+do_install() {
+	oe_runmake install
+	install -d ${D}${libdir}
+	install -m 0644 ${EXPORT_DIR}/lib/libteec.so.1.0.0 ${D}${libdir}
+	install -d ${D}${sbindir}
+	install -m 0744 ${EXPORT_DIR}/sbin/tee-supplicant ${D}${sbindir}
+}

--- a/zynqmp/optee-os/optee-os.bb
+++ b/zynqmp/optee-os/optee-os.bb
@@ -1,0 +1,68 @@
+OPTEE_VERSION ??= "latest"
+SRCREV ??= "${AUTOREV}"
+BRANCH ??= "master"
+
+DESCRIPTION = "OP-TEE OS"
+
+# Define as closed license to prevent MD5 checksum verification since
+# LICENSE file changed around 3.5.0 making this recipe less flexible.
+# LICENSE = "BSD"
+# ante-3.5.0: LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+# post-3.5.0: LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+LICENSE = "CLOSED"
+
+inherit deploy
+
+PROVIDES = "virtual/optee-os"
+DEPENDS += "u-boot-mkimage-native"
+
+S = "${WORKDIR}/git"
+PV = "${OPTEE_VERSION}+git${SRCPV}"
+
+REPO ??= "git://github.com/OP-TEE/optee_os.git;protocol=https"
+SRC_URI = "${REPO};branch=${BRANCH}"
+
+OPTEE_BASE_NAME ?= "${PN}-${PKGE}-${PKGV}-${PKGR}-${DATETIME}"
+OPTEE_BASE_NAME[vardepsexclude] = "DATETIME"
+
+# requires CROSS_COMPILE set by hand as there is no configure script
+export CROSS_COMPILE="${TARGET_PREFIX}"
+
+# Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
+CFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+
+DEBUG ??= "0"
+TA_DEV_KIT_DIR = "${TMPDIR}/deploy/images/${MACHINE}/optee/export-ta_arm64"
+OUTPUT_DIR = "${S}/out/arm-plat-zynqmp"
+TEE_LOG_LEVEL = "${@bb.utils.contains('DEBUG', '1', '3', '2', d)}"
+TEE_CORE_DEBUG = "${@bb.utils.contains('DEBUG', '1', 'y', 'n', d)}"
+
+EXTRA_OEMAKE_append = " comp-cflagscore=--sysroot=${STAGING_DIR_HOST}"
+EXTRA_OEMAKE_append = " CROSS_COMPILE=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " CROSS_COMPILE_core=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " CROSS_COMPILE_ta_arm64=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " PLATFORM=zynqmp"
+EXTRA_OEMAKE_append = " CFG_ARM64_core=y"
+EXTRA_OEMAKE_append = " CFG_ARM32_core=n"
+EXTRA_OEMAKE_append = " CFG_USER_TA_TARGETS=ta_arm64"
+EXTRA_OEMAKE_append = " CFG_TEE_CORE_LOG_LEVEL=${TEE_LOG_LEVEL}"
+EXTRA_OEMAKE_append = " CFG_TEE_CORE_DEBUG=${TEE_CORE_DEBUG}"
+EXTRA_OEMAKE_append = " DEBUG=${DEBUG}"
+
+do_install() {
+	install -d ${TA_DEV_KIT_DIR}
+	cp -aR ${OUTPUT_DIR}/export-ta_arm64/* ${TA_DEV_KIT_DIR}
+}
+
+do_deploy() {
+	install -d ${DEPLOYDIR}
+	install -d ${TMPDIR}/../../images/linux/
+	install -m 0644 ${OUTPUT_DIR}/core/tee.elf ${DEPLOYDIR}/${OPTEE_BASE_NAME}.elf
+	install -m 0644 ${OUTPUT_DIR}/core/tee.elf ${TMPDIR}/../../images/linux/bl32.elf
+	install -m 0644 ${OUTPUT_DIR}/core/tee.bin ${DEPLOYDIR}/${OPTEE_BASE_NAME}.bin
+	install -m 0644 ${OUTPUT_DIR}/core/tee.bin ${TMPDIR}/../../images/linux/bl32.bin
+}
+addtask deploy before do_build after do_install

--- a/zynqmp/optee-test/optee-test.bb
+++ b/zynqmp/optee-test/optee-test.bb
@@ -1,0 +1,40 @@
+OPTEE_VERSION ??= "latest"
+SRCREV ??= "${AUTOREV}"
+BRANCH ??= "master"
+
+DESCRIPTION = "OP-TEE Test"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
+
+PROVIDES = "virtual/optee-test"
+DEPENDS += "virtual/optee-os virtual/optee-client"
+
+S = "${WORKDIR}/git"
+PV = "${OPTEE_VERSION}+git${SRCPV}"
+
+REPO ??= "git://github.com/OP-TEE/optee_test.git;protocol=git"
+SRC_URI = "${REPO};branch=${BRANCH}"
+
+# requires CROSS_COMPILE set by hand as there is no configure script
+export CROSS_COMPILE="${TARGET_PREFIX}"
+
+TA_DEV_KIT_DIR = "${TMPDIR}/deploy/images/${MACHINE}/optee/export-ta_arm64"
+OPTEE_CLIENT_EXPORT = "${TMPDIR}/deploy/images/${MACHINE}/optee/export_client"
+
+EXTRA_OEMAKE_append = " CROSS_COMPILE=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " CROSS_COMPILE_TA=${CROSS_COMPILE}"
+EXTRA_OEMAKE_append = " TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR}"
+EXTRA_OEMAKE_append = " OPTEE_CLIENT_EXPORT=${OPTEE_CLIENT_EXPORT}"
+EXTRA_OEMAKE_append = " COMPILE_NS_USER=64"
+
+do_install() {
+	install -d ${D}/lib/optee_armtz
+	find ${S}/out/ta -type f -iname '*.ta' -exec install -m 0644 {} ${D}/lib/optee_armtz/ \;
+	install -d ${D}${bindir}
+	install -m 0744 ${S}/out/xtest/xtest ${D}${bindir}
+}
+
+FILES_${PN} = "/lib/optee_armtz"
+FILES_${PN} += "/lib"
+FILES_${PN} += "${bindir}"

--- a/zynqmp/system-user.dtsi
+++ b/zynqmp/system-user.dtsi
@@ -1,0 +1,9 @@
+/include/ "system-conf.dtsi"
+/ {
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+};


### PR DESCRIPTION
This commit adds support for Xilinx ZynqMP boards to the OPTEE/build repository.
The provided makefile relies on Xilinx Petalinux 2018.2 itself based on Yocto.
Petalinux and BSP files shall be downloaded from Xilinx website. You may have to create a Xilinx account.
The makefile helps to create, patch and build a customized Petalinux project with OP-TEE support.
Boards can be emulated using Petalinux's QEMU.
xtest test suite pass on Petalinux's QEMU emulating zcu102 board executing Petalinux v2018.2 and OP-TEE 3.4.0