### PR TITLE
buildroot: add optee_os package to copy shared libraries into the root FS

### DIFF
--- a/br-ext/Config.in
+++ b/br-ext/Config.in
@@ -1,3 +1,4 @@
+source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_os/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_client/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_test/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_examples/Config.in"

--- a/br-ext/package/optee_os/CMakeLists.txt
+++ b/br-ext/package/optee_os/CMakeLists.txt
@@ -1,0 +1,3 @@
+# This is a dummy Makefile. When this package is invoked, OP-TEE has been built
+# already, and the only installation step occurs in optee_os.mk.
+install(FILES /dev/null DESTINATION /dev/null)

--- a/br-ext/package/optee_os/Config.in
+++ b/br-ext/package/optee_os/Config.in
@@ -1,0 +1,25 @@
+config BR2_PACKAGE_OPTEE_OS
+	bool "optee_os"
+	help
+	  OP-TEE OS, http://github.org/OP-TEE/optee_os.
+	  NOTE: this package currently only takes care of installing files into
+	  the root FS, that have been compiled already. For example, shared
+	  libraries used by TAs when CFG_ULIBS_SHARED=y.
+	  The build of optee_os itself is assumed to have been done previously.
+
+if BR2_PACKAGE_OPTEE_OS
+
+config BR2_PACKAGE_OPTEE_OS_SITE
+	string "OP-TEE OS installation package path"
+	default ""
+	help
+	  The path to this installation package.
+
+config BR2_PACKAGE_OPTEE_OS_SDK
+	string "OPTEE SDK path"
+	default ""
+	help
+	  The path to export-ta_arm32 or export-ta_arm64 in the optee_os output
+	  directory.
+
+endif

--- a/br-ext/package/optee_os/optee_os.mk
+++ b/br-ext/package/optee_os/optee_os.mk
@@ -1,0 +1,18 @@
+OPTEE_OS_VERSION = 1.0
+OPTEE_OS_SOURCE = local
+OPTEE_OS_SITE = $(BR2_PACKAGE_OPTEE_OS_SITE)
+OPTEE_OS_SITE_METHOD = local
+OPTEE_OS_SDK = $(BR2_PACKAGE_OPTEE_OS_SDK)
+
+define OPTEE_OS_INSTALL_OPTEE_OS_SHLIBS
+	@mkdir -p $(TARGET_DIR)/lib/optee_armtz && \
+		for f in $(OPTEE_OS_SDK)/lib/*.ta; do \
+			[ -f "$f" ] || continue; \
+			$(INSTALL) -v -p  --mode=444 \
+				--target-directory=$(TARGET_DIR)/lib/optee_armtz $$f; \
+		done
+endef
+
+OPTEE_OS_POST_INSTALL_TARGET_HOOKS += OPTEE_OS_INSTALL_OPTEE_OS_SHLIBS
+
+$(eval $(cmake-package))

--- a/common.mk
+++ b/common.mk
@@ -211,6 +211,12 @@ ifneq (,$(BR2_ROOTFS_POST_BUILD_SCRIPT))
 	@echo "BR2_ROOTFS_POST_BUILD_SCRIPT=\"$(BR2_ROOTFS_POST_BUILD_SCRIPT)\"" >> \
 		../out-br/extra.conf
 endif
+	@# The OPTEE_OS package builds nothing, it just installs files into the
+	@# root FS when applicable (for example: shared libraries)
+	@echo "BR2_PACKAGE_OPTEE_OS_SITE=\"$(CURDIR)/br-ext/package/optee_os\"" >> \
+		../out-br/extra.conf
+	@echo "BR2_PACKAGE_OPTEE_OS_SDK=\"$(OPTEE_OS_TA_DEV_KIT_DIR)\"" >> \
+		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \
 		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE=\"$(CROSS_COMPILE_S_USER)\"" >> \
@@ -227,6 +233,7 @@ endif
 		../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_BENCHMARK_SITE=\"$(BENCHMARK_APP_PATH)\"" >> \
 		../out-br/extra.conf
+	@echo "BR2_PACKAGE_OPTEE_OS=y" >> ../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_TEST=y" >> ../out-br/extra.conf
 	@echo "BR2_PACKAGE_OPTEE_EXAMPLES=y" >> ../out-br/extra.conf
 	@echo "BR2_PACKAGE_STRACE=y" >> ../out-br/extra.conf


### PR DESCRIPTION
When OP-TEE is built with CFG_ULIBS_SHARED=y, TA shared libraries are
created. They have to be installed into the target root FS in order
to be found at runtime.

This patch adds a custom package to do just that.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>