### PR TITLE
buildroot: fix installation of shared libraries

### DIFF
--- a/br-ext/package/optee_os/optee_os.mk
+++ b/br-ext/package/optee_os/optee_os.mk
@@ -7,7 +7,7 @@ OPTEE_OS_SDK = $(BR2_PACKAGE_OPTEE_OS_SDK)
 define OPTEE_OS_INSTALL_OPTEE_OS_SHLIBS
 	@mkdir -p $(TARGET_DIR)/lib/optee_armtz && \
 		for f in $(OPTEE_OS_SDK)/lib/*.ta; do \
-			[ -f "$f" ] || continue; \
+			[ -f "$$f" ] || continue; \
 			$(INSTALL) -v -p  --mode=444 \
 				--target-directory=$(TARGET_DIR)/lib/optee_armtz $$f; \
 		done


### PR DESCRIPTION
Fixes a mistake in the optee_os install step which prevents the
libraries from being copied into the root FS staging area.

Fixes: 91ebff727d47 ("buildroot: add optee_os package to copy shared libraries into the root FS")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>