### PR TITLE
qemu_v8: fix "make check"

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -42,7 +42,11 @@ info "Starting QEMU..."
 open "serial1.log" "w+"
 spawn -open [open "|tail -f serial1.log"]
 set teecore $spawn_id
-spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+if {[string first "aarch64" $::env(QEMU)] != -1} {
+	spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,secure=on -cpu cortex-a57 -d unimp -semihosting-config enable,target=native -m 1057 -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -no-acpi -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2"
+} else {
+	spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+}
 expect {
 	"Kernel panic" {
 		info "!!! Kernel panic\n"

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -210,7 +210,11 @@ check-args := --timeout $(TIMEOUT)
 endif
 
 check: $(CHECK_DEPS)
-	expect qemu-check.exp -- $(check-args) || \
+	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
+	cd $(BINARIES_PATH) && \
+		export QEMU=$(QEMU_PATH)/aarch64-softmmu/qemu-system-aarch64 && \
+		export QEMU_SMP=$(QEMU_SMP) && \
+		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \
 			echo "== $$PWD/serial0.log:"; \
 			cat serial0.log; \


### PR DESCRIPTION
Updates qemu_v8.mk and qemu-check.exp so that "make check" and "make
check-only" are supported for QEMUv8, as they are for QEMU.

Signed-off-by: Jerome Forissier <jerome@forissier.org>