### PR TITLE
zynqmp.mk: Add support for Ultra96 ZynqMP board

### DIFF
--- a/zynqmp.mk
+++ b/zynqmp.mk
@@ -1,8 +1,8 @@
 ROOT			= $(PWD)/..
 PLATFORM		?= zcu102
-PETALINUX_PATH		?= /opt/Xilinx/petalinx_2018_2
-BSP_PATH		?= ./xilinx-${PLATFORM}-v2018.2-final.bsp
-PRJ_PATH		?= $(ROOT)/xilinx-${PLATFORM}-2018.2
+PETALINUX_PATH		?= $(PETALINUX)
+BSP_PATH		?= ./xilinx-${PLATFORM}-v$(PETALINUX_VER)-final.bsp
+PRJ_PATH		?= $(ROOT)/$(PLATFORM)-$(PETALINUX_VER)
 PETALINUX_CFG_PATH	?= $(ROOT)/build/zynqmp
 OPTEE_VER		?= latest
 
@@ -20,8 +20,16 @@ define set_optee_version
 	fi
 endef
 
-.PHONY: check-petalinux
+ifeq ($(PLATFORM),ultra96-reva)
+	ZYNQMP_CONSOLE=cadence1
+else
+	ZYNQMP_CONSOLE=cadence0
+endif
 
+.PHONY: all
+all: petalinux-create petalinux-config petalinux-build petalinux-package
+
+.PHONY: check-petalinux
 check-petalinux:
 ifndef PETALINUX_VER
 	$(error You have to source Petalinux settings)
@@ -30,34 +38,61 @@ ifneq ($(PETALINUX_VER),2018.2)
 	$(error This makefile only support Petalinux 2018.2)
 endif
 
-petalinux-create: check-petalinux
-	@cd $(ROOT) && petalinux-create -t project -s $(BSP_PATH)
-	@cd $(PRJ_PATH) && petalinux-create -t apps --template install -n optee-client --enable
-	@cd $(PRJ_PATH) && petalinux-create -t apps --template install -n optee-test --enable
-	@#
+petalinux-create: check-petalinux	
+	@cd $(ROOT) && petalinux-create -n $(PLATFORM)-$(PETALINUX_VER) \
+	    -t project -s $(BSP_PATH)
 	$(call set_cfg,CONFIG_SUBSYSTEM_ATF_COMPILE_EXTRA_SETTINGS,"SPD=opteed ZYNQMP_BL32_MEM_BASE=0x60000000 ZYNQMP_BL32_MEM_SIZE=0x80000",$(PRJ_PATH)/project-spec/configs/config)
 	$(call set_cfg,CONFIG_SUBSYSTEM_ZYNQMP_ATF_MEM_SIZE,0x16001,$(PRJ_PATH)/project-spec/configs/config)
 	@#
-	@cp $(PETALINUX_CFG_PATH)/kernel_optee.cfg $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx/
-	@cp $(PETALINUX_CFG_PATH)/linux-xlnx_%.bbappend $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
-	@cp $(PETALINUX_CFG_PATH)/system-user.dtsi $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/device-tree/files/
+	@# Replace BSP default rootfs by a minimal one to speed up building 
+	@# process and ease compatibility between different boards. Default
+	@# rootfs is saved in rootfs_config_full file
+	@mv $(PRJ_PATH)/project-spec/configs/rootfs_config \
+	    $(PRJ_PATH)/project-spec/configs/rootfs_config_full
+	@cp $(PETALINUX_CFG_PATH)/rootfs_config \
+	    $(PRJ_PATH)/project-spec/configs/
 	@#
+	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx/
+	@cp $(PETALINUX_CFG_PATH)/kernel_optee.cfg \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx/
+	@cp $(PETALINUX_CFG_PATH)/linux-xlnx_%.bbappend \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
+	@cp $(PETALINUX_CFG_PATH)/system-user.dtsi \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/device-tree/files/
+	@#
+	@# Override default TF-A 1.4 with TF-A 1.5 because it does not work with
+	@# OP-TEE
 	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/arm-trusted-firmware/
-	@cp -r $(PETALINUX_CFG_PATH)/arm-trusted-firmware/* $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/arm-trusted-firmware/
+	@cp -r $(PETALINUX_CFG_PATH)/arm-trusted-firmware/* \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/arm-trusted-firmware/
 	@#
+	@petalinux-create -p $(PRJ_PATH) -t apps --template install \
+	    -n optee-client --enable
+	@petalinux-create -p $(PRJ_PATH) -t apps --template install \
+	    -n optee-test --enable
 	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os
-	@cp -r $(PETALINUX_CFG_PATH)/optee-os/* $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os/
-	@cp -r $(PETALINUX_CFG_PATH)/optee-client/* $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/
-	@cp -r $(PETALINUX_CFG_PATH)/optee-test/* $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/
+	@cp -r $(PETALINUX_CFG_PATH)/optee-os/* \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os/
+	@cp -r $(PETALINUX_CFG_PATH)/optee-client/* \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/
+	@cp -r $(PETALINUX_CFG_PATH)/optee-test/* \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/
 	
-petalinux-config:
+petalinux-config: check-petalinux
 	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/optee-test.bbappend)
 	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/optee-client.bbappend)
 	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-bsp/optee-os/optee-os.bbappend)
-	@cd $(PRJ_PATH) && petalinux-config --oldconfig
+	@petalinux-config -p $(PRJ_PATH) --oldconfig
 
-petalinux-build:
-	@cd $(PRJ_PATH) && petalinux-build
+petalinux-build: check-petalinux
+	@petalinux-build -p $(PRJ_PATH)
 	
-qemu:
-	@cd $(PRJ_PATH) && petalinux-boot --qemu --qemu-args "-device loader,file=${PRJ_PATH}/images/linux/bl32.elf" --kernel
+qemu: check-petalinux
+	@cd $(PRJ_PATH) && petalinux-boot --qemu \
+	    --qemu-args "-device loader,file=${PRJ_PATH}/images/linux/bl32.elf" \
+	    --kernel
+
+petalinux-package: check-petalinux
+	@cd $(PRJ_PATH) && petalinux-package --boot --pmufw --fpga --u-boot \
+	    --add ${PRJ_PATH}/images/linux/bl32.elf --cpu a53-0 \
+	    --file-attribute "exception_level=el-1, trustzone" --force

--- a/zynqmp/optee-os/optee-os.bb
+++ b/zynqmp/optee-os/optee-os.bb
@@ -25,6 +25,10 @@ SRC_URI = "${REPO};branch=${BRANCH}"
 OPTEE_BASE_NAME ?= "${PN}-${PKGE}-${PKGV}-${PKGR}-${DATETIME}"
 OPTEE_BASE_NAME[vardepsexclude] = "DATETIME"
 
+COMPATIBLE_MACHINE = "zynqmp"
+PLATFORM_zynqmp = "zynqmp"
+FLAVOR_zynqmp = "${@d.getVar('MACHINE').split('-')[0]}"
+
 # requires CROSS_COMPILE set by hand as there is no configure script
 export CROSS_COMPILE="${TARGET_PREFIX}"
 
@@ -44,7 +48,7 @@ EXTRA_OEMAKE_append = " comp-cflagscore=--sysroot=${STAGING_DIR_HOST}"
 EXTRA_OEMAKE_append = " CROSS_COMPILE=${CROSS_COMPILE}"
 EXTRA_OEMAKE_append = " CROSS_COMPILE_core=${CROSS_COMPILE}"
 EXTRA_OEMAKE_append = " CROSS_COMPILE_ta_arm64=${CROSS_COMPILE}"
-EXTRA_OEMAKE_append = " PLATFORM=zynqmp"
+EXTRA_OEMAKE_append = " PLATFORM=${PLATFORM}-${FLAVOR}"
 EXTRA_OEMAKE_append = " CFG_ARM64_core=y"
 EXTRA_OEMAKE_append = " CFG_ARM32_core=n"
 EXTRA_OEMAKE_append = " CFG_USER_TA_TARGETS=ta_arm64"

--- a/zynqmp/rootfs_config
+++ b/zynqmp/rootfs_config
@@ -1,0 +1,14 @@
+CONFIG_mtd-utils=y
+CONFIG_canutils=y
+CONFIG_openssh-sftp-server=y
+CONFIG_pciutils=y
+CONFIG_run-postinsts=y
+CONFIG_packagegroup-core-boot=y
+CONFIG_packagegroup-core-ssh-dropbear=y
+CONFIG_tcf-agent=y
+CONFIG_bridge-utils=y
+CONFIG_hellopm=y
+CONFIG_udev-extraconf=y
+CONFIG_ultra96-ap-setup=y
+CONFIG_packagegroup-base-extended=y
+CONFIG_ROOTFS_ROOT_PASSWD="root"


### PR DESCRIPTION
This PR adds support for Ultra96 board.
It relies on ultra96 flavor added to OP-TEE ZynqMP platform.
zynqmp makefile is modified in the following way:
- Default BSP rootfs is replaced by a minimal rootfs which supports
zcu10x and Ultra96 boards.
- New petalinux-package target available to generate BOOT.BIN file.