### PR TITLE
hikey, hikey960: remove unused variable STRACE_PATH

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -49,7 +49,6 @@ NVME_IMG			?=$(ROOT)/out/nvme.img
 GRUB_PATH			?=$(ROOT)/grub
 LLOADER_PATH			?=$(ROOT)/l-loader
 PATCHES_PATH			?=$(ROOT)/patches_hikey
-STRACE_PATH			?=$(ROOT)/strace
 
 ################################################################################
 # Targets

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -45,7 +45,6 @@ LLOADER_PATH			?=$(ROOT)/l-loader
 IMAGE_TOOLS_PATH		?=$(ROOT)/tools-images-hikey960
 IMAGE_TOOLS_CONFIG		?=$(OUT_PATH)/config
 PATCHES_PATH			?=$(ROOT)/patches_hikey
-STRACE_PATH			?=$(ROOT)/strace
 
 ################################################################################
 # Targets


### PR DESCRIPTION
STRACE_PATH is a leftover from before buildroot and is not used anymore
so remove it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>