### PR TITLE
rpi3: set BR2_TARGET_GENERIC_GETTY_PORT

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -9,7 +9,7 @@ override COMPILE_S_USER    := 64
 override COMPILE_S_KERNEL  := 64
 
 # Need to set this before including common.mk
-BUILDROOT_GETTY_PORT ?= ttyS0
+BR2_TARGET_GENERIC_GETTY_PORT ?= ttyS0
 BR2_ROOTFS_POST_BUILD_SCRIPT ?= "board/raspberrypi3-64/post-build.sh"
 
 include common.mk


### PR DESCRIPTION
In commit (7fbd6ce22a) "common.mk: buildroot: append BR2_ variables to
config automatically", flags were refactored and the old
BUILDROOT_GETTY_PORT got replaced with BR2_TARGET_GENERIC_GETTY_PORT.
Because of that Rpi3 didn't spawn a console when booting up. By setting
BR2_TARGET_GENERIC_GETTY_PORT to ttyS0 things will work again.

@glneo , I believe the `dra7xx am57xx am43xx` also suffer from this. If you can confirm, then I can add patches for them too in this PR.