### PR TITLE
ti platforms: set BR2_TARGET_GENERIC_GETTY_PORT

### DIFF
--- a/am43xx.mk
+++ b/am43xx.mk
@@ -9,7 +9,7 @@ override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
 # Need to set this before including common.mk
-BUILDROOT_GETTY_PORT ?= ttyS0
+BR2_TARGET_GENERIC_GETTY_PORT ?= ttyS0
 
 ###############################################################################
 # Includes

--- a/am57xx.mk
+++ b/am57xx.mk
@@ -9,7 +9,7 @@ override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
 # Need to set this before including common.mk
-BUILDROOT_GETTY_PORT ?= ttyS2
+BR2_TARGET_GENERIC_GETTY_PORT ?= ttyS2
 
 ###############################################################################
 # Includes

--- a/dra7xx.mk
+++ b/dra7xx.mk
@@ -9,7 +9,7 @@ override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
 # Need to set this before including common.mk
-BUILDROOT_GETTY_PORT ?= ttyS0
+BR2_TARGET_GENERIC_GETTY_PORT ?= ttyS0
 
 ###############################################################################
 # Includes


### PR DESCRIPTION
In commit (7fbd6ce22a) "common.mk: buildroot: append BR2_ variables to
config automatically", flags were refactored and the old
BUILDROOT_GETTY_PORT got replaced with BR2_TARGET_GENERIC_GETTY_PORT.

TI platforms (am43xx, am57xx and dra7xx) were'nt updated hence the wrong
ttyAMA0 were used instead of ttyS0 (am43xx and dra7xx) and ttyS2
(am57xx). By setting BR2_TARGET_GENERIC_GETTY_PORT properly, this issue
gets resolved.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>