### PR TITLE
Fix #389: OP-TEE test build statement overflowing execvp

### DIFF
--- a/br-ext/package/optee_examples/optee_examples.mk
+++ b/br-ext/package/optee_examples/optee_examples.mk
@@ -8,11 +8,13 @@ OPTEE_EXAMPLES_SDK = $(BR2_PACKAGE_OPTEE_EXAMPLES_SDK)
 OPTEE_EXAMPLES_CONF_OPTS = -DOPTEE_EXAMPLES_SDK=$(OPTEE_EXAMPLES_SDK)
 
 define OPTEE_EXAMPLES_BUILD_TAS
-	@$(foreach f,$(wildcard $(@D)/*/ta/Makefile), \
-		echo Building $f && \
+	@for f in $(@D)/*/ta/Makefile; \
+	do \
+	  echo Building $$f && \
 			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE))" \
 			O=out TA_DEV_KIT_DIR=$(OPTEE_EXAMPLES_SDK) \
-			$(TARGET_CONFIGURE_OPTS) -C $(dir $f) all &&) true
+			$(TARGET_CONFIGURE_OPTS) -C $${f%/*} all; \
+	done
 endef
 
 define OPTEE_EXAMPLES_INSTALL_TAS

--- a/br-ext/package/optee_test/optee_test.mk
+++ b/br-ext/package/optee_test/optee_test.mk
@@ -8,11 +8,13 @@ OPTEE_TEST_SDK = $(BR2_PACKAGE_OPTEE_TEST_SDK)
 OPTEE_TEST_CONF_OPTS = -DOPTEE_TEST_SDK=$(OPTEE_TEST_SDK)
 
 define OPTEE_TEST_BUILD_TAS
-	@$(foreach f,$(wildcard $(@D)/ta/*/Makefile), \
-		echo Building $f && \
-			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE))" \
-			O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_SDK) \
-			$(TARGET_CONFIGURE_OPTS) -C $(dir $f) all &&) true
+	@for f in $(@D)/ta/*/Makefile; \
+	do \
+	  echo Building $$f && \
+	  $(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE))" \
+	  O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_SDK) \
+	  $(TARGET_CONFIGURE_OPTS) -C $${f%/*} all; \
+	done
 endef
 
 define OPTEE_TEST_INSTALL_TAS


### PR DESCRIPTION
The PR consists of 2 commits for easier review, as the issue might also affect the build of examples.
The first commit fixes https://github.com/OP-TEE/build/issues/389, the second commit adapts the fix for examples.

If desired, both commits can be merged when adding the Reviewed-By-line to the commit message or the second commit can be split of into its own PR.