### PR TITLE
br-ext: optee_test: use ta/Makefile.gmake instead of enumerating TAs

### DIFF
--- a/br-ext/package/optee_test/optee_test.mk
+++ b/br-ext/package/optee_test/optee_test.mk
@@ -8,13 +8,9 @@ OPTEE_TEST_SDK = $(BR2_PACKAGE_OPTEE_TEST_SDK)
 OPTEE_TEST_CONF_OPTS = -DOPTEE_TEST_SDK=$(OPTEE_TEST_SDK)
 
 define OPTEE_TEST_BUILD_TAS
-	@for f in $(@D)/ta/*/Makefile; \
-	do \
-	  echo Building $$f && \
 	  $(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE))" \
 	  O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_SDK) \
-	  $(TARGET_CONFIGURE_OPTS) -C $${f%/*} all; \
-	done
+	  $(TARGET_CONFIGURE_OPTS) -C $(@D)/ta -f $(@D)/ta/Makefile.gmake
 endef
 
 define OPTEE_TEST_INSTALL_TAS


### PR DESCRIPTION
Invoke the main TA makefile instead of enumerating and building all TAs
unconditionally, in order to properly deal with dependencies and
configuration-specific aspects such as:
 - os_test depends on os_test_lib
 - sdp_basic does not need to be built unless CFG_SECURE_DATA_PATH=y

Depends on optee_test commit xxxxxxxxxxxx ("ta: buildroot: preserve
ta/Makefile as ta/Makefile.gmake") [1].

Link: [1] https://github.com/OP-TEE/optee_test/commit/xxxxxxxxxxxx
Signed-off-by: Jerome Forissier <jerome@forissier.org>