### PR TITLE
qemu, qemu_v8: do not build Linux modules

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -118,7 +118,7 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm
+LINUX_COMMON_FLAGS += ARCH=arm zImage
 
 linux: linux-common
 	mkdir -p $(BINARIES_PATH)

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -142,7 +142,7 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm64
+LINUX_COMMON_FLAGS += ARCH=arm64 zImage
 
 linux: linux-common
 	mkdir -p $(BINARIES_PATH)


### PR DESCRIPTION
The QEMU and QEMUv8 builds do not need any kernel module to boot and
run xtest etc. so we can save build time by only building the kernel
image by default.

Signed-off-by: Jerome Forissier <jerome@forissier.org>