### PR TITLE
qemu_v8: fix linux build

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -142,7 +142,7 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm64 zImage
+LINUX_COMMON_FLAGS += ARCH=arm64 Image
 
 linux: linux-common
 	mkdir -p $(BINARIES_PATH)


### PR DESCRIPTION
The kernel image for QEMUv8 is Image, not zImage (there is no
compressed image support in Linux for arm64). Fix the makefile.

Fixes: c54f4f51fafb ("qemu, qemu_v8: do not build Linux modules")
Signed-off-by: Jerome Forissier <jerome@forissier.org>