### PR TITLE
hikey960: fix EDK2 build with GCC 9.x

### DIFF
--- a/hikey960.mk
+++ b/hikey960.mk
@@ -121,6 +121,7 @@ endif
 
 define edk2-call
 	$(EDK2_TOOLCHAIN)_$(EDK2_ARCH)_PREFIX=$(AARCH64_CROSS_COMPILE) \
+	BUILD_CC="gcc -Wno-error=stringop-truncation" \
 	build -n `getconf _NPROCESSORS_ONLN` -a $(EDK2_ARCH) \
 		-t $(EDK2_TOOLCHAIN) -p $(EDK2_DSC) \
 		-b $(EDK2_BUILD) $(EDK2_BUILDFLAGS)


### PR DESCRIPTION
The current EDK2 code fails to build with GCC 9.x:

 make[3]: Entering directory '/home/jerome/work/optee_repo_hikey960/edk2/BaseTools/Source/C/GenVtf'
 gcc  -c -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-unused-result -nostdlib -c -g  -I .. -I ../Include/Common -I ../Include/ -I ../Include/IndustryStandard -I ../Common/ -I .. -I . -I ../Include/X64/  -O2 GenVtf.c -o GenVtf.o
 In file included from /usr/include/string.h:494,
                  from ../Common/FvLib.h:21,
                  from GenVtf.c:19:
 In function ‘strncpy’,
     inlined from ‘ConvertVersionInfo’ at GenVtf.c:132:7:
 /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
   106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 GenVtf.c: In function ‘ConvertVersionInfo’:
 GenVtf.c:130:14: note: length computed here
   130 |     Length = strlen(Str);
       |              ^~~~~~~~~~~
 In file included from /usr/include/string.h:494,
                  from ../Common/FvLib.h:21,
                  from GenVtf.c:19:
 In function ‘strncpy’,
     inlined from ‘CreateFitTableAndInitialize’ at GenVtf.c:1532:3:
 /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output truncated before terminating nul copying 8 bytes from a string of the same length [-Werror=stringop-truncation]
   106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cc1: all warnings being treated as errors
 make[3]: *** [../Makefiles/footer.makefile:27: GenVtf.o] Error 1

This error was found with Ubuntu 19.10 (comes with GCC 9.2.1).

The HiKey960 EDK2 repository [1] has not received any update in the
past year, I am not sure it is still maintained. There is apparently
some support for HiKey960 in the upstream EDK2 repositories [2] and
[3], but I could not get my board to boot with upstream code.

So, a quick fix seems in order.

[1] https://github.com/96boards-hikey/edk2.git
[2] https://github.com/tianocore/edk2.git
[3] https://github.com/tianocore/edk2-platforms.git

Signed-off-by: Jerome Forissier <jerome@forissier.org>