### PR TITLE
hikey960: fix EDK2 build with GCC 9.x

### DIFF
--- a/hikey960.mk
+++ b/hikey960.mk
@@ -121,7 +121,6 @@ endif
 
 define edk2-call
 	$(EDK2_TOOLCHAIN)_$(EDK2_ARCH)_PREFIX=$(AARCH64_CROSS_COMPILE) \
-	BUILD_CC="gcc -Wno-error=stringop-truncation" \
 	build -n `getconf _NPROCESSORS_ONLN` -a $(EDK2_ARCH) \
 		-t $(EDK2_TOOLCHAIN) -p $(EDK2_DSC) \
 		-b $(EDK2_BUILD) $(EDK2_BUILDFLAGS)
@@ -132,7 +131,8 @@ edk2:
 	cd $(EDK2_PATH) && rm -rf OpenPlatformPkg && \
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
-		$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools && \
+		$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools \
+			BUILD_CC="gcc -Wno-error=stringop-truncation" && \
 		$(call edk2-call)
 
 .PHONY: edk2-clean


### PR DESCRIPTION
Actually fix the build error mentioned in the below commit. The
variable BUILD_CC is set at the wrong place (I think I had it set as
an environment variable when I tested this, which is why it would work
anyways).

Fixes: 1e8d0b5a2b38 ("hikey960: fix EDK2 build with GCC 9.x")
Signed-off-by: Jerome Forissier <jerome@forissier.org>