### PR TITLE
hikey: fix EDK2 build with GCC 9.x

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -148,6 +148,19 @@ endef
 
 DEBUG ?= 0
 
+# Macro to check if a compiler supports a given option
+# For example: $(call cc-option,gcc,-Wno-error=stringop-truncation,)
+#   ...will return -Wno-error=stringop-truncation if gcc supports it, empty
+#   otherwise.
+__cc-option = $(if $(shell $(1) $(2) -c -x c /dev/null -o /dev/null 2>&1 >/dev/null),$(3),$(2))
+_cc-opt-cached-var-name = cached-cc-option$(subst =,~,$(strip $(2)))$(subst $(empty) $(empty),,$(1))
+define _cc-option
+$(eval _cached := $(call _cc-opt-cached-var-name,$1,$2))
+$(eval $(_cached) := $(if $(filter $(origin $(_cached)),undefined),$(call __cc-option,$(1),$(2),$(3)),$($(_cached))))
+$($(_cached))
+endef
+cc-option = $(strip $(call _cc-option,$(1),$(2),$(3)))
+
 ################################################################################
 # default target is all
 ################################################################################

--- a/hikey.mk
+++ b/hikey.mk
@@ -135,7 +135,8 @@ edk2:
 	cd $(EDK2_PATH) && rm -rf OpenPlatformPkg && \
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
-		$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools && \
+		$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools \
+			BUILD_CC="gcc $(call cc-option,gcc,-Wno-error=stringop-truncation,)" && \
 		$(call edk2-call)
 
 .PHONY: edk2-clean

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -132,7 +132,7 @@ edk2:
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \
 		$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools \
-			BUILD_CC="gcc -Wno-error=stringop-truncation" && \
+			BUILD_CC="gcc $(call cc-option,gcc,-Wno-error=stringop-truncation,)" && \
 		$(call edk2-call)
 
 .PHONY: edk2-clean


### PR DESCRIPTION
Fix EDK2 build error when host compiler is GCC 9.x. This is the same fix
as the one recently applied to hikey960.mk.

Signed-off-by: Jerome Forissier <jerome@forissier.org>