### PR TITLE
hikey: do not build kernel modules

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -169,7 +169,7 @@ linux-gen_init_cpio: linux-defconfig
 		LOCALVERSION= \
 		gen_init_cpio
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image modules hisilicon/hi6220-hikey.dtb
+LINUX_COMMON_FLAGS += ARCH=arm64 Image hisilicon/hi6220-hikey.dtb
 
 .PHONY: linux
 linux: linux-common


### PR DESCRIPTION
We currently do not copy any kernel module into our root FS, they are
not needed. Therefore, drop the "modules" target when building the
kernel to save compile time.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>