### PR TITLE
zynqmp: add missing Python package build dependencies

### DIFF
--- a/zynqmp.mk
+++ b/zynqmp.mk
@@ -77,6 +77,9 @@ petalinux-create: check-petalinux
 	    $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-client/
 	@cp -r $(PETALINUX_CFG_PATH)/optee-test/* \
 	    $(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/
+	@mkdir -p $(PRJ_PATH)/project-spec/meta-user/recipes-devtools/python
+	@cp -r $(PETALINUX_CFG_PATH)/python/* \
+	    $(PRJ_PATH)/project-spec/meta-user/recipes-devtools/python/
 	
 petalinux-config: check-petalinux
 	$(call set_optee_version,$(OPTEE_VER),$(PRJ_PATH)/project-spec/meta-user/recipes-apps/optee-test/optee-test.bbappend)

--- a/zynqmp/optee-os/optee-os.bb
+++ b/zynqmp/optee-os/optee-os.bb
@@ -11,16 +11,21 @@ DESCRIPTION = "OP-TEE OS"
 # post-3.5.0: LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 LICENSE = "CLOSED"
 
-inherit deploy
-
 PROVIDES = "virtual/optee-os"
-DEPENDS += "u-boot-mkimage-native"
+DEPENDS += "\
+            u-boot-mkimage-native \
+            python3-pycryptodome-native \
+            python3-pycryptodomex-native \
+            python3-pyelftools-native \
+            "
 
 S = "${WORKDIR}/git"
 PV = "${OPTEE_VERSION}+git${SRCPV}"
 
 REPO ??= "git://github.com/OP-TEE/optee_os.git;protocol=https"
 SRC_URI = "${REPO};branch=${BRANCH}"
+
+inherit deploy python3native
 
 OPTEE_BASE_NAME ?= "${PN}-${PKGE}-${PKGV}-${PKGR}-${DATETIME}"
 OPTEE_BASE_NAME[vardepsexclude] = "DATETIME"

--- a/zynqmp/optee-test/optee-test.bb
+++ b/zynqmp/optee-test/optee-test.bb
@@ -8,13 +8,20 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 PROVIDES = "virtual/optee-test"
-DEPENDS += "virtual/optee-os virtual/optee-client"
+DEPENDS += "\
+            virtual/optee-os \
+            virtual/optee-client \
+            python3-pycryptodome-native \
+            python3-pycryptodomex-native\
+            "
 
 S = "${WORKDIR}/git"
 PV = "${OPTEE_VERSION}+git${SRCPV}"
 
 REPO ??= "git://github.com/OP-TEE/optee_test.git;protocol=git"
 SRC_URI = "${REPO};branch=${BRANCH}"
+
+inherit python3native
 
 # requires CROSS_COMPILE set by hand as there is no configure script
 export CROSS_COMPILE="${TARGET_PREFIX}"

--- a/zynqmp/python/python-pycryptodome.inc
+++ b/zynqmp/python/python-pycryptodome.inc
@@ -1,0 +1,29 @@
+SUMMARY = "Cryptographic library for Python"
+DESCRIPTION = "PyCryptodome is a self-contained Python package of low-level\
+ cryptographic primitives."
+HOMEPAGE = "http://www.pycryptodome.org"
+LICENSE = "PD & BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=6dc0e2a13d2f25d6f123c434b761faba"
+
+SRC_URI[md5sum] = "c4e53f9ed33ca883b18249b9e1546251"
+SRC_URI[sha256sum] = "39ddc3c493125494572e0beefa8e8e6a43369e93c3c3e163cb871b37c1c62fba"
+
+inherit pypi
+
+RDEPENDS_${PN} += " \
+    ${PYTHON_PN}-io \
+    ${PYTHON_PN}-math \
+"
+
+RDEPENDS_${PN}-tests += " \
+    ${PYTHON_PN}-unittest \
+"
+
+PACKAGES =+ "${PN}-tests"
+
+FILES_${PN}-tests += " \
+    ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/ \
+    ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/__pycache__/ \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/zynqmp/python/python-pycryptodomex.inc
+++ b/zynqmp/python/python-pycryptodomex.inc
@@ -1,0 +1,29 @@
+SUMMARY = "Cryptographic library for Python"
+DESCRIPTION = "PyCryptodome is a self-contained Python package of low-level\
+ cryptographic primitives."
+HOMEPAGE = "http://www.pycryptodome.org"
+LICENSE = "PD & BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=6dc0e2a13d2f25d6f123c434b761faba"
+
+SRC_URI[md5sum] = "3a34a9c337c4ba9f388ace099d733fc5"
+SRC_URI[sha256sum] = "e87c272263559d657ab3b990be8174c0d492cbc2f4f8d0bddfaef82dfe05d54c"
+
+inherit pypi
+
+RDEPENDS_${PN} += " \
+    ${PYTHON_PN}-io \
+    ${PYTHON_PN}-math \
+"
+
+RDEPENDS_${PN}-tests += " \
+    ${PYTHON_PN}-unittest \
+"
+
+PACKAGES =+ "${PN}-tests"
+
+FILES_${PN}-tests += " \
+    ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/ \
+    ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/__pycache__/ \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/zynqmp/python/python-pyelftools.inc
+++ b/zynqmp/python/python-pyelftools.inc
@@ -1,0 +1,14 @@
+DESCRIPTION = "pyelftools is a pure-Python library for parsing and analyzing ELF files and DWARF debugging information"
+HOMEPAGE = "https://github.com/eliben/pyelftools"
+SECTION = "devel/python"
+LICENSE = "PD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5ce2a2b07fca326bc7c146d10105ccfc"
+
+SRC_URI[md5sum] = "c5629b9a5d19c82107a946cce52eeec2"
+SRC_URI[sha256sum] = "89c6da6f56280c37a5ff33468591ba9a124e17d71fe42de971818cbff46c1b24"
+
+PYPI_PACKAGE = "pyelftools"
+
+inherit pypi
+
+BBCLASSEXTEND = "native"

--- a/zynqmp/python/python3-pycryptodome_3.9.3.bb
+++ b/zynqmp/python/python3-pycryptodome_3.9.3.bb
@@ -1,0 +1,2 @@
+require python-pycryptodome.inc
+inherit setuptools3

--- a/zynqmp/python/python3-pycryptodomex_3.9.3.bb
+++ b/zynqmp/python/python3-pycryptodomex_3.9.3.bb
@@ -1,0 +1,2 @@
+require python-pycryptodomex.inc
+inherit setuptools3

--- a/zynqmp/python/python3-pyelftools_0.25.bb
+++ b/zynqmp/python/python3-pyelftools_0.25.bb
@@ -1,0 +1,2 @@
+inherit setuptools3
+require python-pyelftools.inc


### PR DESCRIPTION
Currently one has to patch the PetaLinux installation to add these
missing dependencies. However, there should be no need to touch the
installation, which is often not feasible in e.g. corporate environments
anyway. Different OP-TEE releases require different dependencies; this
patch has been tested for all releases down to 3.4.0.

See OP-TEE/optee_docs#54 for the corresponding documentation pull request.