### PR TITLE
br-ext: break build as soon as one TA fails to build

### DIFF
--- a/br-ext/package/optee_examples/optee_examples.mk
+++ b/br-ext/package/optee_examples/optee_examples.mk
@@ -8,13 +8,13 @@ OPTEE_EXAMPLES_SDK = $(BR2_PACKAGE_OPTEE_EXAMPLES_SDK)
 OPTEE_EXAMPLES_CONF_OPTS = -DOPTEE_EXAMPLES_SDK=$(OPTEE_EXAMPLES_SDK)
 
 define OPTEE_EXAMPLES_BUILD_TAS
-	@for f in $(@D)/*/ta/Makefile; \
+	@(set -e; for f in $(@D)/*/ta/Makefile; \
 	do \
 	  echo Building $$f && \
 			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_EXAMPLES_CROSS_COMPILE))" \
 			O=out TA_DEV_KIT_DIR=$(OPTEE_EXAMPLES_SDK) \
 			$(TARGET_CONFIGURE_OPTS) -C $${f%/*} all; \
-	done
+	done)
 endef
 
 define OPTEE_EXAMPLES_INSTALL_TAS

--- a/br-ext/package/optee_test/optee_test.mk
+++ b/br-ext/package/optee_test/optee_test.mk
@@ -8,13 +8,13 @@ OPTEE_TEST_SDK = $(BR2_PACKAGE_OPTEE_TEST_SDK)
 OPTEE_TEST_CONF_OPTS = -DOPTEE_TEST_SDK=$(OPTEE_TEST_SDK)
 
 define OPTEE_TEST_BUILD_TAS
-	@for f in $(@D)/ta/*/Makefile; \
+	@(set -e; for f in $(@D)/ta/*/Makefile; \
 	do \
 	  echo Building $$f && \
 	  $(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_CROSS_COMPILE))" \
 	  O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_SDK) \
 	  $(TARGET_CONFIGURE_OPTS) -C $${f%/*} all; \
-	done
+	done)
 endef
 
 define OPTEE_TEST_INSTALL_TAS


### PR DESCRIPTION
If an error occurs when building a TA, the error does not stop the
build. It may therefore go unnoticed if files have been generated
previously.

This patch updates the buildroot hooks that deals with TAs and breaks
the loop as soon as a TA faiils to build. A non-zero status is left to
the caller (a Buildroot makefile) and the build stops as expected.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
