### PR TITLE
verdin-imx8mm: add initial setup

### DIFF
--- a/verdin.mk
+++ b/verdin.mk
@@ -1,0 +1,180 @@
+################################################################################
+# Following variables defines how the NS_USER (Non Secure User - Client
+# Application), NS_KERNEL (Non Secure Kernel), S_KERNEL (Secure Kernel) and
+# S_USER (Secure User - TA) are compiled
+################################################################################
+COMPILE_NS_USER   ?= 64
+override COMPILE_NS_KERNEL := 64
+COMPILE_S_USER    ?= 64
+COMPILE_S_KERNEL  ?= 64
+
+BR2_TARGET_GENERIC_GETTY_PORT = ttymxc0
+################################################################################
+# Includes
+################################################################################
+include common.mk
+
+################################################################################
+# Paths to git projects and various binaries
+################################################################################
+OUT_PATH		?= $(ROOT)/out
+ROOTFS_BIN		?= $(ROOT)/out-br/images/rootfs.tar
+TF_A_PATH		?= $(ROOT)/trusted-firmware-a
+UBOOT_PATH		?= $(ROOT)/u-boot
+OPTEE_CLIENT_EXPORT	?= $(OPTEE_CLIENT_PATH)/out/export
+OPTEE_PATH		?= $(ROOT)/optee_os
+LINUX_PATH		?= $(ROOT)/linux
+
+LINUX_DTB		?= $(LINUX_PATH)/arch/arm64/boot/dts/freescale/fsl-imx8mm-verdin-dev.dtb
+MODULE_OUTPUT		?= $(ROOT)/module_output
+
+UBOOT_BIN		?= $(UBOOT_PATH)/flash.bin
+OPTEE_ELF		?= $(OPTEE_PATH)/out/arm/core/tee.elf
+
+DDR_URL			?= https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-imx-8.1.1.bin
+DDR_PATH		?= $(ROOT)/ddr-firmware
+
+ATF_LOAD_ADDR		?= 0x920000
+TEE_LOAD_ADDR		?= 0xbe000000
+
+
+################################################################################
+# Targets
+################################################################################
+.PHONY: all
+all: u-boot arm-tf buildroot linux prepare-images | toolchains
+
+.PHONY: clean
+clean: u-boot-clean arm-tf-clean linux-clean optee-os-clean \
+	buildroot-clean
+
+################################################################################
+# Toolchain
+################################################################################
+include toolchain.mk
+
+################################################################################
+# U-Boot
+################################################################################
+.PHONY: u-boot-config
+u-boot-config:
+ifeq ($(wildcard $(UBOOT_PATH)/.config),)
+	$(MAKE) -C $(UBOOT_PATH) \
+		CROSS_COMPILE=$(AARCH64_CROSS_COMPILE) verdin-imx8mm_defconfig
+endif
+
+.PHONY: u-boot-menuconfig
+u-boot-menuconfig: u-boot-config
+	$(MAKE) -C $(UBOOT_PATH) \
+		CROSS_COMPILE=$(AARCH64_CROSS_COMPILE) menuconfig
+
+.PHONY: u-boot
+u-boot: u-boot-config arm-tf optee-os ddr-firmware
+	# Copy BL31 binary from TF-A
+	cp $(TF_A_PATH)/build/imx8mm/release/bl31.bin $(UBOOT_PATH)
+	# Prepare proper tee.bin
+	$(AARCH64_CROSS_COMPILE)objcopy -O binary \
+		$(OPTEE_ELF) $(UBOOT_PATH)/tee.bin
+	# Copy DDR4 firmware
+	cp $(DDR_PATH)/firmware-imx-8.1.1/firmware/ddr/synopsys/lpddr4*.bin \
+		$(UBOOT_PATH)
+	# Build U-Boot and final ready-to-flash flash.bin image
+	ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) \
+	$(MAKE) -C $(UBOOT_PATH) \
+		CROSS_COMPILE="$(AARCH64_CROSS_COMPILE)" flash.bin
+
+.PHONY: u-boot-clean
+u-boot-clean:
+	cd $(UBOOT_PATH) && git clean -xdf
+
+################################################################################
+# DDR4 Firmware
+################################################################################
+.PHONY: ddr-firmware
+ddr-firmware:
+	# DDR is exported to the $PWD only, so cd to $(DDR_PATH)
+	# before unpacking
+	if [ ! -d "$(DDR_PATH)" ]; then \
+		mkdir -p $(DDR_PATH) && \
+		wget $(DDR_URL) -O $(DDR_PATH)/firmware.bin && \
+		chmod +x $(DDR_PATH)/firmware.bin && \
+		cd $(DDR_PATH) && \
+		$(DDR_PATH)/firmware.bin --auto-accept && \
+		cd $(ROOT)/build; \
+	fi;
+
+.PHONY: ddr-firmware-clean
+ddr-firmware-clean:
+	rm -rf $(DDR_PATH)
+
+################################################################################
+# ARM Trusted Firmware
+################################################################################
+.PHONY: arm-tf
+arm-tf:
+	$(MAKE) -C $(TF_A_PATH) \
+		PLAT=imx8mm \
+		CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" \
+		SPD=opteed \
+		bl31
+
+.PHONY: arm-tf-clean
+arm-tf-clean:
+	cd $(TF_A_PATH) && git clean -xdf
+
+################################################################################
+# OP-TEE
+################################################################################
+OPTEE_OS_COMMON_FLAGS += PLATFORM=imx PLATFORM_FLAVOR=mx8mmevk CFG_ARM64_core=y CFG_UART_BASE=0x30860000
+OPTEE_OS_CLEAN_COMMON_FLAGS += PLATFORM=imx-mx8mmevk
+
+.PHONY: optee-os
+optee-os: optee-os-common
+
+.PHONY: optee-os-clean
+optee-os-clean: optee-os-clean-common
+
+################################################################################
+# Linux
+################################################################################
+LINUX_DEFCONFIG_COMMON_ARCH := arm64
+LINUX_DEFCONFIG_COMMON_FILES := \
+		$(LINUX_PATH)/arch/arm64/configs/defconfig \
+
+linux-defconfig: $(LINUX_PATH)/.config
+
+LINUX_COMMON_FLAGS += ARCH=arm64
+
+linux: linux-common
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) freescale/fsl-imx8mm-verdin-dev.dtb
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) INSTALL_MOD_STRIP=1 \
+		INSTALL_MOD_PATH=$(MODULE_OUTPUT) modules_install
+
+linux-defconfig-clean: linux-defconfig-clean-common
+
+LINUX_CLEAN_COMMON_FLAGS += ARCH=arm64
+
+linux-clean: linux-clean-common
+
+LINUX_CLEANER_COMMON_FLAGS += ARCH=arm64
+
+linux-cleaner: linux-cleaner-common
+
+.PHONY: prepare-images
+prepare-images: linux u-boot buildroot
+	@mkdir -p $(OUT_PATH)
+	@cp $(UBOOT_BIN) $(OUT_PATH)
+	@cp $(LINUX_PATH)/arch/arm64/boot/Image $(OUT_PATH)
+	@cp $(LINUX_DTB) $(OUT_PATH)
+	@cp $(ROOT)/out-br/images/rootfs.tar $(OUT_PATH)
+
+################################################################################
+# Buildroot/RootFS
+################################################################################
+.PHONY: update_rootfs
+update_rootfs: u-boot linux
+	@cd $(MODULE_OUTPUT) && find . | cpio -pudm $(BUILDROOT_TARGET_ROOT)
+	@cd $(ROOT)/build
+
+.PHONY: buildroot
+buildroot: update_rootfs


### PR DESCRIPTION
Add initial verdin.mk for the minimal setup for OP-TEE testing.
This setup uses latest mainline TF-A (v.2.2) / U-Boot (v2020.03) /
Linux (5.6-rc).

Verdin i.MX8M Mini boot sequence:
```
BootROM -> SPL -> TF-A (BL31) -> OP-TEE (BL32)
                   |
                   -> U-Boot (BL33) -> Linux
```
TF-A(bl31.bin), U-Boot proper and OP-TEE (tee.bin) are packed in FIT image,
which is parsed by SPL.

Deploying:

1. Flasing flash.bin (IMX ready-to-boot image):
```
> dhcp && tftpboot ${loadaddr} flash.bin
> setexpr blkcnt ${filesize} + 0x1ff
> setexpr blkcnt ${blkcnt} / 0x200
> mmc dev 0 1 && mmc write ${loadaddr} 0x2 ${blkcnt}
```
2. Boot Linux kernel via TFTP/NFS:
```
-> setenv serverip <ip_of_your_server>
-> setenv nfsroot /path/to/nfs/root
-> setenv fdt_file fsl-imx8mm-verdin-dev.dtb
-> setenv bootargs "console=${console},${baudrate} root=/dev/nfs \
            ip=dhcp nfsroot=${serverip}:${nfsroot},v3,tcp"
-> tftp ${loadaddr} ${image}; tftp ${fdt_addr} ${fdt_file};
-> booti ${loadaddr} - ${fdt_addr}
```
Test results:
```
+-----------------------------------------------------
24600 subtests of which 0 failed
98 test cases of which 0 failed
0 test cases were skipped
TEE test application done!
```
`Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>`

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
