### PR TITLE
toolchain.mk: add clang-toolchains target

### DIFF
--- a/get_clang.sh
+++ b/get_clang.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Download and extract Clang from the GitHub release page.
+# We want a x86_64 cross-compiler capable of generating aarch64 and armv7a code
+# *and* we want the compiler-rt libraries for these architectures
+# (libclang_rt.*.a).
+# Clang is configured to be able to cross-compile to all the supported
+# architectures by default (see <clang path>/bin/llc --version) which is great,
+# but compiler-rt is included only for the host architecture. Therefore we need
+# to combine several packages into one, which is the purpose of this script.
+#
+# Usage: get_clang.sh [path]
+
+DEST=${1:-./clang-9.0.1}
+
+VER=9.0.1
+X86_64=clang+llvm-${VER}-x86_64-linux-gnu-ubuntu-16.04
+AARCH64=clang+llvm-${VER}-aarch64-linux-gnu
+ARMV7A=clang+llvm-${VER}-armv7a-linux-gnueabihf
+
+set -x
+
+TMPDEST=${DEST}_tmp${RANDOM}
+
+if [ -e ${TMPDEST} ]; then
+  echo Error: ${TMPDEST} exists
+  exit 1
+fi
+
+function cleanup() {
+  rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
+  rm -rf ${AARCH64} ${ARMV7A}
+}
+
+trap "{ exit 2; }" INT
+trap cleanup EXIT
+
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${X86_64}.tar.xz && tar xf ${X86_64}.tar.xz) &
+pids=$!
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${AARCH64}.tar.xz && tar xf ${AARCH64}.tar.xz) &
+pids="$pids $!"
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${ARMV7A}.tar.xz && tar xf ${ARMV7A}.tar.xz) &
+pids="$pids $!"
+
+wait $pids || exit 1
+
+mv ${X86_64} ${TMPDEST} || exit 1
+cp ${AARCH64}/lib/clang/${VER}/lib/linux/* ${TMPDEST}/lib/clang/${VER}/lib/linux || exit 1
+cp ${ARMV7A}/lib/clang/${VER}/lib/linux/* ${TMPDEST}/lib/clang/${VER}/lib/linux || exit 1
+mv ${TMPDEST} ${DEST}

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -37,3 +37,18 @@ aarch32:
 .PHONY: aarch64
 aarch64:
 	$(call dltc,$(AARCH64_PATH),$(SRC_AARCH64_GCC),$(AARCH64_GCC_VERSION))
+
+CLANG_PATH			?= $(ROOT)/clang-9.0.1
+
+# Download the Clang compiler with LLVM tools and compiler-rt libraries
+define dl-clang
+	@if [ ! -d "$(1)" ]; then \
+		./get_clang.sh $(1); \
+	else \
+		echo "$(1) already exists"; \
+	fi
+endef
+
+.PHONY: clang-toolchains
+clang-toolchains:
+	$(call dl-clang,$(CLANG_PATH))


### PR DESCRIPTION
Add "make clang-toolchains" to download and extract Clang 9.0.1 into
$(ROOT)/clang-9.0.1. Usage:

 $ make clang-toolchains
 $ PATH=../clang-9.0.1/bin:$PATH make COMPILER=clang

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
