### PR TITLE
hikey: do not call hisi-idt.py with hardcoded python command

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -347,7 +347,7 @@ recovery:
 	@echo
 	$(call flash_help)
 	@echo
-	python $(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/recovery.bin
+	$(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/recovery.bin
 	fastboot flash loader $(LLOADER_PATH)/l-loader.bin
 	@echo
 	@echo "3. Wait until you see the (UART) message"


### PR DESCRIPTION
Let hisi-idt.py decide which python interpreter is used based on the
hashbang line. Calling "python" can cause compatibility problems when
"python" is Python 2 but the script needs Python3.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
