### PR TITLE
qemu: update u-boot config fragment for v2019.01 to v2020.04

### DIFF
--- a/kconfigs/u-boot_qemu_virt_v7.conf
+++ b/kconfigs/u-boot_qemu_virt_v7.conf
@@ -1,3 +1,7 @@
 CONFIG_SYS_TEXT_BASE=0x60000000
 CONFIG_BOOTCOMMAND="fdt addr ${fdt_addr} && fdt resize 1000 && smhload zImage ${kernel_addr_r} && smhload rootfs.cpio.gz ${ramdisk_addr_r} ramdisk_addr_end &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 && fdt chosen ${ramdisk_addr_r} ${ramdisk_addr_end} && bootz ${kernel_addr_r} - ${fdt_addr}"
 CONFIG_SEMIHOSTING=y
+CONFIG_ENV_IS_NOWHERE=y
+# CONFIG_ENV_IS_IN_FLASH is not set
+# CONFIG_MTD is not set
+# CONFIG_MTD_NOR_FLASH is not set


### PR DESCRIPTION
Update U-Boot config fragment to support more recent U-Boot version than currently used v2018.07 
 in Qemu/Armv7 setup.

A later change in OP-TEE manifest repo will dump U-Boot to latest stable version v2020.04 for the Qemu/Armv7 manifest.
