### PR TITLE
hikey.mk: update help text for 'make flash'

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -367,7 +367,8 @@ ifneq ($(FROM_RECOVERY),1)
 	@echo
 	$(call flash_help)
 	@echo "3. Wait until you see the (UART) message"
-	@echo "    \"Android Fastboot mode - version x.x Press any key to quit.\""
+	@echo "    \"Android Fastboot mode - version x.x.\""
+	@echo "     Press RETURN or SPACE key to quit.\""
 endif
 	@read -r -p "Then press enter to continue flashing" dummy
 	@echo


### PR DESCRIPTION
The EDK2/UEFI welcome message when booting into fastboot mode has
changed since a while ago [1], but we never updated it correspondingly
in our Makefile, so do it now.

LINK: [1] https://github.com/96boards-hikey/edk2/commit/f5d1102d7bf42ede641520c5c228a0e51139a58e
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
