### PR TITLE
Makefiles were modified to enable another shared folder for QEMU, to …

### DIFF
--- a/br-ext/board/qemu/overlay/mnt/host/README
+++ b/br-ext/board/qemu/overlay/mnt/host/README
@@ -1,0 +1,2 @@
+This directory is intended to be mounted onto a shared directory on the host.
+See QEMU_VIRTFS_AUTOMOUNT / QEMU_VIRTFS_MOUNTPOINT in build/common.mk.

--- a/br-ext/board/qemu/post-build.sh
+++ b/br-ext/board/qemu/post-build.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2020, Roland Nagy <rnagy@xmimx.tk>
+
+TARGETDIR="$1"
+VIRTFS_AUTOMOUNT="$2"
+VIRTFS_MOUNTPOINT="$3"
+PSS_AUTOMOUNT="$4"
+
+if [[ -z $TARGET_DIR ]]; then
+    echo "TARGET_DIR missing"
+    exit 1
+fi
+
+if [[ -z $VIRTFS_AUTOMOUNT ]]; then
+    echo "VIRTFS_AUTOMOUNT missing"
+    exit 1
+fi
+
+if [[ -z $VIRTFS_MOUNTPOINT ]]; then
+    echo "VIRTFS_MOUNTPOINT missing"
+    exit 1
+fi
+
+if [[ -z $PSS_AUTOMOUNT ]]; then
+    echo "PSS_AUTOMOUNT missing"
+    exit 1
+fi
+
+
+if [[ $VIRTFS_AUTOMOUNT == "y" ]]; then
+    grep host "$TARGETDIR"/etc/fstab > /dev/null || \
+    echo "host $VIRTFS_MOUNTPOINT 9p trans=virtio,version=9p2000.L,rw 0 0" >> "$TARGETDIR"/etc/fstab
+    echo "[+] shared directory mount added to fstab"
+fi
+
+if [[ $PSS_AUTOMOUNT == "y" ]]; then
+    mkdir -p "$TARGETDIR"/data/tee
+    grep secure "$TARGETDIR"/etc/fstab > /dev/null || \
+    echo "secure /data/tee 9p trans=virtio,version=9p2000.L,rw 0 0" >> "$TARGET_DIR"/etc/fstab
+    echo "[+] persistent secure storage mount added to fstab"
+fi

--- a/qemu.mk
+++ b/qemu.mk
@@ -9,6 +9,8 @@ override COMPILE_S_USER    := 32
 override COMPILE_S_KERNEL  := 32
 
 BR2_ROOTFS_OVERLAY = $(ROOT)/build/br-ext/board/qemu/overlay
+BR2_ROOTFS_POST_BUILD_SCRIPT = $(ROOT)/build/br-ext/board/qemu/post-build.sh
+BR2_ROOTFS_POST_SCRIPT_ARGS = "$(QEMU_VIRTFS_AUTOMOUNT) $(QEMU_VIRTFS_MOUNTPOINT) $(QEMU_PSS_AUTOMOUNT)"
 
 OPTEE_OS_PLATFORM = vexpress-qemu_virt
 

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -14,6 +14,8 @@ override COMPILE_S_KERNEL  := 64
 TF_A_TRUSTED_BOARD_BOOT ?= n
 
 BR2_ROOTFS_OVERLAY = $(ROOT)/build/br-ext/board/qemu/overlay
+BR2_ROOTFS_POST_BUILD_SCRIPT = $(ROOT)/build/br-ext/board/qemu/post-build.sh
+BR2_ROOTFS_POST_SCRIPT_ARGS = "$(QEMU_VIRTFS_AUTOMOUNT) $(QEMU_VIRTFS_MOUNTPOINT) $(QEMU_PSS_AUTOMOUNT)"
 
 OPTEE_OS_PLATFORM = vexpress-qemu_armv8a
 


### PR DESCRIPTION
…preserve the content of the secure storage between reboots.

Usage: set QEMU_PPS_ENABLE=y and adjust QEMU_PPS_HOST_DIR. It also
requires QEMU_VIRTFS_ENABLE to be set to "y".

Also added a buildroot post-script which appends lines to /etc/fstab,
so shared directories can be automatically mounted if
QEMU_VIRTFS_AUTOMOUNT and QEMU_PPS_AUTOMOUNT are set to "y".

Signed-off-by: Roland Nagy <rnagy@xmimx.tk>