### PR TITLE
qemu-check.exp: clean assertion failure message

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -99,7 +99,7 @@ expect {
 	"+-----------------------------------------------------\r\r" {}
 	# Handle errors in TEE core output
 	-i $teecore -re {(assertion.*failed at.*)\n} {
-		info "!!! TEE core assertion failed: '$expect_out(1,string)'\n"
+		info "!!! $expect_out(1,string)\n"
 		exit 1
 	}
 	timeout {


### PR DESCRIPTION
The message displayed by "make check" when an assertion failure is
detected is redundant and possibly misleading. For instance:

 $ PATH=~/work/clang-10.0.0/bin:$PATH make -j10 COMPILER=clang check
 [...]
 Starting QEMU... done, guest is booted.
 Running: xtest...
 '##########!!! TEE core assertion failed: 'assertion 'maps[map_idx].sz == sz' failed at ldelf/ta_elf.c:1351 in ta_elf_print_mappings()
 make: *** [Makefile:221: check] Error 1
 $

The "TEE core assertion failed:' part is not needed and possibly
misleading in this case (the assertion occured in ldelf which is
arguably not "TEE core"). Remove it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
