### PR TITLE
fvp: update path to simulator

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -198,7 +198,7 @@ run: all
 
 run-only:
 	@cd $(FOUNDATION_PATH); \
-	$(FOUNDATION_PATH)/models/Linux64_GCC-4.9/Foundation_Platform \
+	$(FOUNDATION_PATH)/models/Linux64_GCC-6.4/Foundation_Platform \
 	--arm-v8.0 \
 	--cores=4 \
 	--secure-memory \


### PR DESCRIPTION
The path to the simulator when unpacked has changed in recent FVP
foundation model. Adjusting the path to match the latest version
11.11_34.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
