### PR TITLE
optee_test_ext.mk: make sure TAs are built in correct order

### DIFF
--- a/br-ext/package/optee_test_ext/optee_test_ext.mk
+++ b/br-ext/package/optee_test_ext/optee_test_ext.mk
@@ -6,9 +6,12 @@ OPTEE_TEST_EXT_INSTALL_STAGING = YES
 OPTEE_TEST_EXT_DEPENDENCIES = optee_client_ext openssl host-python-pycrypto
 OPTEE_TEST_EXT_SDK = $(BR2_PACKAGE_OPTEE_TEST_EXT_SDK)
 OPTEE_TEST_EXT_CONF_OPTS = -DOPTEE_TEST_SDK=$(OPTEE_TEST_EXT_SDK)
+# os_test has dependencies, this enforces a valid build order
+OPTEE_TEST_EXT_TAS = os_test_lib os_test_lib_dl os_test *
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
 define OPTEE_TEST_EXT_BUILD_TAS
-	@$(foreach f,$(wildcard $(@D)/ta/*/Makefile), \
+	@$(foreach f,$(call uniq,$(foreach t,$(OPTEE_TEST_EXT_TAS),$(wildcard $(@D)/ta/$(t)/Makefile))), \
 		echo Building $f && \
 			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_EXT_CROSS_COMPILE))" \
 			O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_EXT_SDK) \


### PR DESCRIPTION
The optee_test TAs are built by a $(wildcard ...) loop. This is
unreliable because there is no guarantee that os_test_lib and
os_test_lib_dl will appear before os_test in the list. Yet os_test
depends on the libraries being built first.

Fix the issue by explicitely listing the libraries and TAs with
dependencies in the correct order, then using a wildcard for the other
TAs.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
