### PR TITLE
Added Network support and ssh related packages

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -12,6 +12,16 @@ override COMPILE_S_KERNEL  := 64
 BR2_TARGET_GENERIC_GETTY_PORT ?= ttyS0
 BR2_ROOTFS_POST_BUILD_SCRIPT ?= "board/raspberrypi3-64/post-build.sh"
 
+# Network support related packages:
+BR2_PACKAGE_DHCPCD ?= y
+BR2_PACKAGE_ETHTOOL ?= y
+BR2_PACKAGE_XINETD ?= y
+
+# SSH Packages :
+BR2_PACKAGE_OPENSSH ?= y
+BR2_PACKAGE_OPENSSH_SERVER ?= y
+BR2_PACKAGE_OPENSSH_KEY_UTILS ?= y
+
 OPTEE_OS_PLATFORM = rpi3
 
 include common.mk


### PR DESCRIPTION
Intermingled logs on RPI3B+ https://github.com/OP-TEE/optee_client/issues/234

In this issue I wanted to ssh onto my rpi3 board so that the normal and secure world logs could be separated . During this course of action I realised my rpi3 board was not able to connect to the local network and to resolve it I have done the following.

I have added the below mentioned packages in order to get an IP assigned to the raspberry pi board and also to ssh onto it from the host Ubuntu. 
**Reason :** By default after buillding the image from the cloned the sources of the build.git for raspberrypi-3 (rpi3) board , I tried to ssh onto my board. 
I figured it out that these packages are missing and were needed to get an IP assigned from the dhcp and also ssh server related packages were needed inorder to connect to the rpi3 board from ssh client( Ubuntu).  
As it was clearly specified in the op-tee documentation that the default developer build contains minimal support and additional packages need to be added via Buildroot , I have added these packages here in common.mk file so that the buildroot takes care while building the Root file system. I have tested the same after adding these packages on my rpi3 board and was successful in getting an IP assigned from the dhcp and later ssh on to it.

**In this issue (https://github.com/OP-TEE/optee_client/issues/234) Intermingled logs on RPI3B+**  after discussing with @vchong I have sent this pull request. 
Hope this helps you in getting a clear picture of the issue and solution to it.
Thank you.


Internet Support related packages:
```
BR2_PACKAGE_DHCPCD ?= y
BR2_PACKAGE_ETHTOOL ?= y
BR2_PACKAGE_XINETD ?= y
```
SSH Packages :
```
BR2_PACKAGE_OPENSSH ?= y
BR2_PACKAGE_OPENSSH_SERVER ?= y
BR2_PACKAGE_OPENSSH_KEY_UTILS ?= y
```

Signed-off-by : Jayanth Dodderi Chidanand <jayanthchidanand94@gmail.com>
Reviewed-by : Joakim Bech <joakim.bech@linaro.org>
Acked-by : Etienne Carriere <etienne.carriere@linaro.org>