### PR TITLE
poplar: default enable CFG_ENABLE_EMBEDDED_TESTS for optee-os

### DIFF
--- a/poplar.mk
+++ b/poplar.mk
@@ -107,7 +107,8 @@ arm-tf-clean:
 ################################################################################
 # OP-TEE
 ################################################################################
-OPTEE_OS_COMMON_FLAGS += CFG_ARM64_core=y CFG_DRAM_SIZE_GB=1
+OPTEE_OS_COMMON_FLAGS += CFG_ARM64_core=y CFG_DRAM_SIZE_GB=1 \
+			 CFG_ENABLE_EMBEDDED_TESTS=y
 
 .PHONY: optee-os
 optee-os: optee-os-common


### PR DESCRIPTION
Default enable CFG_ENABLE_EMBEDDED_TESTS for OP-TEE os for Poplar.

Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
