### PR TITLE
rpi3: recommend 64MB for the boot partition

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -183,7 +183,7 @@ img-help:
 	@echo "   > p             # create primary"
 	@echo "   > 1             # make it the first partition"
 	@echo "   > <enter>       # use the default sector"
-	@echo "   > +32M          # create a boot partition with 32MB of space"
+	@echo "   > +64M          # create a boot partition with 64MB of space"
 	@echo "   > n             # create rootfs partition"
 	@echo "   > p"
 	@echo "   > 2"


### PR DESCRIPTION
(This doesn't matter whether it's merged right away of after the 3.12.0 release)

In some cases depending on configurations etc 32MB is a bit tight for
the boot partition. By increasing it to 64MB you are in a better
position for not hitting the limit. Likewise you can store additional
kernel versions in the boot partition which can be useful when debugging
issues showing up in one kernel build, but not the other. Because of
this the help text should state 64MB instead of 32MB.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
