### PR TITLE
qemu_v8: use Python 3 when building EDK2

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -122,7 +122,7 @@ qemu-clean:
 # EDK2 / Tianocore
 ################################################################################
 define edk2-env
-	export WORKSPACE=$(EDK2_PATH)
+	export WORKSPACE=$(EDK2_PATH) PYTHON3_ENABLE=TRUE
 endef
 
 define edk2-call


### PR DESCRIPTION
Set PYTHON3_ENABLE=TRUE so that EDK2 is built with Python 3. Python 2 is
deprecated. Requires EDK2 tag edk2-stable201905 or later.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
