### PR TITLE
qemu: provide correct ram value

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -177,7 +177,7 @@ run-only:
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on -cpu cortex-a15 \
 		-d unimp -semihosting-config enable,target=native \
-		-m 1057 \
+		-m 1024 \
 		-bios bl1.bin \
 		$(QEMU_EXTRA_ARGS)
 

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -203,7 +203,7 @@ run-only:
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on -cpu cortex-a57 \
 		-d unimp -semihosting-config enable,target=native \
-		-m 1057 \
+		-m 1024 \
 		-bios bl1.bin \
 		-initrd rootfs.cpio.gz \
 		-kernel Image -no-acpi \


### PR DESCRIPTION
```
With this commit 3fa914af82("arm: qemu: implement enable_caches()")
introduced in U-Boot, which enables I and D caches for qemu-arm target,
U-Boot hangs every time during dram_bank_mmu_setup() invocation:

DRAM:  1 GiB
initcall: 60011df8
initcall: 60011904
New Stack Pointer is: 80fffe90
initcall: 60011a20
initcall: 60011bcc
initcall: 60011bd4
initcall: 600119b4
Relocation Offset is: 22042000
Relocating to 82042000, new gd at 81001ed0, sp at 80fffe90
initcall: 60011b8c
initcall: 82053ea0
initcall: 82053ea8
initcall: 60012040 (relocated to 82054040)
dram_bank_mmu_setup: bank: 0

Presumably this happens because of incorrect mem value provided to
QEMU.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```