### PR TITLE
common.mk: qemu: do not build docs

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -370,7 +370,8 @@ edk2-clean-common:
 ################################################################################
 # QEMU / QEMUv8
 ################################################################################
-QEMU_CONFIGURE_PARAMS_COMMON = --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error"
+QEMU_CONFIGURE_PARAMS_COMMON = --cc="$(CCACHE)gcc" --extra-cflags="-Wno-error" \
+			       --disable-docs
 QEMU_EXTRA_ARGS +=\
 	-object rng-random,filename=/dev/urandom,id=rng0 \
 	-device virtio-rng-pci,rng=rng0,max-bytes=1024,period=1000


### PR DESCRIPTION
Add the --disable-docs option to QEMU_CONFIGURE_PARAMS_COMMON so that no
documentation is generated during the QEMU build. Documentation is not
needed and it may fail to build in some environments. For instance on
Ubuntu 18.04.5 LTS:

 Warning, treated as error:
 docs/qemu-option-trace.rst.inc:4:Malformed option description '[enable=]PATTERN', should look like "opt", "-opt args", "--opt args", "/opt args" or "+opt args"
 make[1]: *** [.docs_built_system_qemu.1_docs_built_system_qemu-block-drivers.7_docs_built_system_qemu-cpu-models.7.sentinel.] Error 2

The error is caused by sphinx-build:

 $ sphinx-build --version
 sphinx-build 3.2.1

The version that comes with Ubuntu 20.04.1 LTS works fine:

 $ sphinx-build --version
 sphinx-build 1.8.5

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
