### PR TITLE
Add support for custom `HOSTFWD`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -389,7 +389,7 @@ endif
 endif
 
 ifeq ($(GDBSERVER),y)
-HOSTFWD := ,hostfwd=tcp::12345-:12345
+HOSTFWD := $(HOSTFWD),hostfwd=tcp::12345-:12345
 endif
 # Enable QEMU SLiRP user networking
 QEMU_EXTRA_ARGS +=\


### PR DESCRIPTION
It is alas not possible to use `+=` as it automatically adds a space which breaks the arguments up and results in an error from QEMU...

Refer to #403 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
