### PR TITLE
qemu, qemuv8: avoid needless rebuilds

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -81,9 +81,11 @@ arm-tf-clean:
 ################################################################################
 # QEMU
 ################################################################################
-qemu:
+$(QEMU_PATH)/config-host.mak:
 	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
+
+qemu: $(QEMU_PATH)/config-host.mak
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -110,9 +110,11 @@ arm-tf-clean:
 ################################################################################
 # QEMU
 ################################################################################
-qemu:
+$(QEMU_PATH)/config-host.mak:
 	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
+
+qemu: $(QEMU_PATH)/config-host.mak
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:


### PR DESCRIPTION
The qemu target currently runs the configure script unconditionally
which takes some time and causes unnecessary recompilations.

Split the configuration and the build steps and make the configuration
depend on $(QEMU_PATH)/config-host.mak to avoid the above issue.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
