### PR TITLE
qemu_v8: fix error in edk2-clean

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -356,7 +356,7 @@ edk2-common:
 .PHONY: edk2-clean-common
 edk2-clean-common:
 	$(call edk2-env) && \
-	export PACKAGES_PATH=$(EDK2_PATH):$(ROOT)/edk2-platforms && \
+	export PACKAGES_PATH=$(EDK2_PATH):$(EDK2_PLATFORMS_PATH) && \
 	source $(EDK2_PATH)/edksetup.sh && \
 	$(MAKE) -j1 -C $(EDK2_PATH)/BaseTools clean && \
 	$(call edk2-call) cleanall


### PR DESCRIPTION
'make edk2-clean' fails with the following error:

 build.py...
  : error 000E: One Path in PACKAGES_PATH doesn't exist
         /home/jerome/work/optee_repo_qemu_v8/edk2/../edk2-platforms

The reason is $(ROOT)/edk2-platforms does not exist on this platform.
Fix this by using the proper platform-specific variable
$(EDK2_PLATFORMS_PATH) in the edk2-clean-common target like is done in
edk2-common.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
