### PR TITLE
Update the EDK2 toolchain and QEMU invoking commands

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -23,6 +23,7 @@ TF_A_PATH			?= $(ROOT)/trusted-firmware-a
 BINARIES_PATH			?= $(ROOT)/out/bin
 U-BOOT_PATH			?= $(ROOT)/u-boot
 QEMU_PATH			?= $(ROOT)/qemu
+QEMU_BUILD			?= $(QEMU_PATH)/build
 SOC_TERM_PATH			?= $(ROOT)/soc_term
 
 DEBUG = 1
@@ -81,11 +82,11 @@ arm-tf-clean:
 ################################################################################
 # QEMU
 ################################################################################
-$(QEMU_PATH)/config-host.mak:
+$(QEMU_BUILD)/config-host.mak:
 	cd $(QEMU_PATH); ./configure --target-list=arm-softmmu\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 
-qemu: $(QEMU_PATH)/config-host.mak
+qemu: $(QEMU_BUILD)/config-host.mak
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:
@@ -173,7 +174,7 @@ run-only:
 	$(call launch-terminal,54320,"Normal World")
 	$(call launch-terminal,54321,"Secure World")
 	$(call wait-for-ports,54320,54321)
-	cd $(BINARIES_PATH) && $(QEMU_PATH)/arm-softmmu/qemu-system-arm \
+	cd $(BINARIES_PATH) && $(QEMU_BUILD)/arm-softmmu/qemu-system-arm \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
 		-smp $(QEMU_SMP) \
@@ -195,7 +196,7 @@ endif
 check: $(CHECK_DEPS)
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	cd $(BINARIES_PATH) && \
-		export QEMU=$(ROOT)/qemu/arm-softmmu/qemu-system-arm && \
+		export QEMU=$(QEMU_BUILD)/arm-softmmu/qemu-system-arm && \
 		export QEMU_SMP=$(QEMU_SMP) && \
 		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -38,6 +38,7 @@ EDK2_BUILD		?= RELEASE
 endif
 EDK2_BIN		?= $(EDK2_PATH)/Build/ArmVirtQemuKernel-$(EDK2_ARCH)/$(EDK2_BUILD)_$(EDK2_TOOLCHAIN)/FV/QEMU_EFI.fd
 QEMU_PATH		?= $(ROOT)/qemu
+QEMU_BUILD		?= $(QEMU_PATH)/build
 SOC_TERM_PATH		?= $(ROOT)/soc_term
 
 ################################################################################
@@ -110,11 +111,11 @@ arm-tf-clean:
 ################################################################################
 # QEMU
 ################################################################################
-$(QEMU_PATH)/config-host.mak:
+$(QEMU_BUILD)/config-host.mak:
 	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 
-qemu: $(QEMU_PATH)/config-host.mak
+qemu: $(QEMU_BUILD)/config-host.mak
 	$(MAKE) -C $(QEMU_PATH)
 
 qemu-clean:
@@ -199,7 +200,7 @@ run-only:
 	$(call launch-terminal,54320,"Normal World")
 	$(call launch-terminal,54321,"Secure World")
 	$(call wait-for-ports,54320,54321)
-	cd $(BINARIES_PATH) && $(QEMU_PATH)/aarch64-softmmu/qemu-system-aarch64 \
+	cd $(BINARIES_PATH) && $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 \
 		-nographic \
 		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
 		-smp $(QEMU_SMP) \
@@ -223,7 +224,7 @@ endif
 check: $(CHECK_DEPS)
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	cd $(BINARIES_PATH) && \
-		export QEMU=$(QEMU_PATH)/aarch64-softmmu/qemu-system-aarch64 && \
+		export QEMU=$(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 && \
 		export QEMU_SMP=$(QEMU_SMP) && \
 		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -29,7 +29,7 @@ DEBUG ?= 1
 TF_A_PATH		?= $(ROOT)/trusted-firmware-a
 BINARIES_PATH		?= $(ROOT)/out/bin
 EDK2_PATH		?= $(ROOT)/edk2
-EDK2_TOOLCHAIN		?= GCC49
+EDK2_TOOLCHAIN		?= GCC5
 EDK2_ARCH		?= AARCH64
 ifeq ($(DEBUG),1)
 EDK2_BUILD		?= DEBUG


### PR DESCRIPTION
As discussed in https://github.com/OP-TEE/manifest/issues/179
+ Older EDK2 toolchains (GCC49) will cause errors when updating EDK2, therefore, we use GCC5 instead.
+ QEMU has adopted meson as the build system. As a result, the output of QEMU will be located in the $(QEMU_PATH)/build, so we should reflect this change.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
