### PR TITLE
common: remove deprecated dependency for optee-os-clean-common

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -448,8 +448,5 @@ optee-os-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS)
 
 .PHONY: optee-os-clean-common
-ifeq ($(CFG_TEE_BENCHMARK),y)
-optee-os-clean-common: benchmark-app-clean-common
-endif
-optee-os-clean-common: xtest-clean-common optee-examples-clean-common
+optee-os-clean-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS) clean


### PR DESCRIPTION
Remove deprecated dependencies on target optee-os-clean-common. The targets where removed by commit 819066fb88a6.

Fixes build failure with trace like:
```bash
  bash> make clean -j$(nproc)
  (...)
  make: *** No rule to make target 'xtest-clean-common', needed by 'optee-os-clean-common'.  Stop.
```
