### PR TITLE
toolchain: update to Clang 12.0.0

### DIFF
--- a/get_clang.sh
+++ b/get_clang.sh
@@ -11,9 +11,8 @@
 #
 # Usage: get_clang.sh [path]
 
-DEST=${1:-./clang-9.0.1}
-
-VER=9.0.1
+VER=12.0.0
+DEST=${1:-./clang-${VER}}
 X86_64=clang+llvm-${VER}-x86_64-linux-gnu-ubuntu-16.04
 AARCH64=clang+llvm-${VER}-aarch64-linux-gnu
 ARMV7A=clang+llvm-${VER}-armv7a-linux-gnueabihf

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -40,7 +40,7 @@ aarch32:
 aarch64:
 	$(call dltc,$(AARCH64_PATH),$(SRC_AARCH64_GCC),$(AARCH64_GCC_VERSION))
 
-CLANG_PATH			?= $(ROOT)/clang-9.0.1
+CLANG_PATH			?= $(ROOT)/clang-12.0.0
 
 # Download the Clang compiler with LLVM tools and compiler-rt libraries
 define dl-clang


### PR DESCRIPTION
Clang 12.0.0 was released on April 15 2021 (with amd64 binaries uploaded
on April 22). It notably fixes the following llvm-objdump warnings [1]:
```
 $ make COMPILER=clang optee-os 2>&1 | grep -B 1 objdump
   OBJDUMP out/arm/core/tee.dmp
 llvm-objdump: warning: 'out/arm/core/tee.elf': failed to parse debug information for out/arm/core/tee.elf
 --
   OBJDUMP out/arm/ldelf/ldelf.dmp
 llvm-objdump: warning: 'out/arm/ldelf/ldelf.elf': failed to parse debug information for out/arm/ldelf/ldelf.elf
 --
   OBJDUMP out/arm/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.dmp
 llvm-objdump: warning: 'out/arm/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.elf': failed to parse debug information for out/arm/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.elf
 --
   OBJDUMP out/arm/ta/pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee.dmp
 llvm-objdump: warning: 'out/arm/ta/pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee.elf': failed to parse debug information for out/arm/ta/pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee.elf
```
Link: [1] https://github.com/OP-TEE/optee_os/issues/3808
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
