### PR TITLE
stm32mp1: fix DTB path in STM32MP15C-ED1 extlinux file

### DIFF
--- a/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-STM32MP157C-ED1/boot/extlinux/extlinux.conf
+++ b/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-STM32MP157C-ED1/boot/extlinux/extlinux.conf
@@ -2,5 +2,5 @@ TIMEOUT 20
 DEFAULT stm32mp15-buildroot
 LABEL stm32mp15-buildroot
   kernel /boot/uImage
-  devicetree /boot/stm32mp157c-ev1.dtb
+  devicetree /boot/stm32mp157c-ed1.dtb
   append root=/dev/mmcblk0p8 rootwait rw console=ttySTM0,115200


### PR DESCRIPTION
Fix path of the DTB file for ED1 that wrongly pointed to the EV1 DTB
file path.

Fixes: 4dc6908c60bf ("stm32mp1: define STM32MP15C-ED1")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
