### PR TITLE
imx: add a compilation flag to support the persistence of the rootfs.

### DIFF
--- a/imx/u-boot_boot_script
+++ b/imx/u-boot_boot_script
@@ -13,5 +13,10 @@ else
 fi;
 fdt print /firmware/optee;
 run loadimage;
-fatload mmc ${mmcdev}:${mmcpart}  ${initrd_addr} ramdisk.img;
-booti ${loadaddr} ${initrd_addr} ${fdt_addr};
+if fatload mmc ${mmcdev}:${mmcpart}  ${initrd_addr} ramdisk.img; then
+	booti ${loadaddr} ${initrd_addr} ${fdt_addr};
+else
+	echo "Booting on the persistent file system ..."
+	run loadimage;run mmcargs;
+	booti ${loadaddr} - ${fdt_addr};
+fi;


### PR DESCRIPTION
Hello,

Here is a pull request as discussed in [issue 476](https://github.com/OP-TEE/build/issues/476). It enhances the compilation process for the NXP i.MX 8MQuad Evaluation Kit, so the rootfs can be located on a partition and be persisted across boots instead of relying on a RAMDisk. This feature can be enabled using the compilation flag `USE_PERSISTENT_ROOTFS=1`.

I have also refactored the image generation, so the size depends on its content, rather than having a fixed size of 128MiB.

I have run `xtest` with the rootfs located on RAMDisk and a physical partition on an SD card, and both report successful results:
```
25843 subtests of which 0 failed
92 test cases of which 0 failed
0 test cases were skipped
TEE test application done!
```

Feel free to ask for script improvements, I am not that fluent in writing makefiles.

Cheers