### PR TITLE
toolchain: check host architecture before downloading

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -4,15 +4,28 @@
 SHELL				= /bin/bash
 ROOT				?= $(CURDIR)/..
 TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
+UNAME_M				:= $(shell uname -m)
 
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
 AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
-AARCH32_GCC_VERSION 		?= gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
-SRC_AARCH32_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/$(AARCH32_GCC_VERSION).tar.xz
 
 AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
 AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
-AARCH64_GCC_VERSION 		?= gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu
+
+ifeq ($(UNAME_M),x86_64)
+AARCH32_GCC_VERSION		?= gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
+AARCH64_GCC_VERSION		?= gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu
+endif
+
+ifeq ($(AARCH32_GCC_VERSION),)
+$(error Host architecture $(UNAME_M) is not officially supported, and custom 32-bit toolchain was not defined)
+endif
+
+ifeq ($(AARCH64_GCC_VERSION),)
+$(error Host architecture $(UNAME_M) is not officially supported, and custom 64-bit toolchain was not defined)
+endif
+
+SRC_AARCH32_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/$(AARCH32_GCC_VERSION).tar.xz
 SRC_AARCH64_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/$(AARCH64_GCC_VERSION).tar.xz
 
 # Download toolchain macro for saving some repetition


### PR DESCRIPTION
Official opt-tee builds are only supported on 64-bit x86
machines. This change will make the tool error out if
someone tries to build it on different architecture without
providing name of own toolchain.

Signed-off-by: Mefistotelis <mefistotelis@gmail.com>

Related ticket:
https://github.com/OP-TEE/optee_docs/issues/112

off-topic: the auto-comment visible on PR creation contains outdated link to guidelines.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
