### PR TITLE
qemu_v8: add scripts_gdb to LINUX_COMMON_FLAGS

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -218,10 +218,9 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image
+LINUX_COMMON_FLAGS += ARCH=arm64 Image scripts_gdb
 
 linux: linux-common
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) scripts_gdb
 	mkdir -p $(BINARIES_PATH)
 	ln -sf $(LINUX_PATH)/arch/arm64/boot/Image $(BINARIES_PATH)
 


### PR DESCRIPTION
Commit c993ec995a9e ("qemu_v8.mk: add scripts_gdb kernel build target")
has added "$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) scripts_gdb" to the
linux: recipe. Since linux: depends on linux-common which already runs
"$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS)", and since
$(LINUX_COMMON_FLAGS) contains "Image", the Image target is made twice.
It is more efficient to remove the added line and add scripts_gdb to
LINUX_COMMON_FLAGS instead.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
