### PR TITLE
qemu_v8.mk: do not warn about unreadable kernel if XEN_BOOT != y

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -346,11 +346,13 @@ XEN_TMP ?= $(BINARIES_PATH)/xen_files
 $(XEN_TMP):
 	mkdir -p $@
 
+ifeq ($(XEN_BOOT),y)
 # virt-make-fs needs to be able to read the local kernel
 # See https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
 build-host-vmlinuz := $(shell echo /boot/vmlinuz-`uname -r`)
 $(if $(shell [ -r $(build-host-vmlinuz) ] || echo No), \
   $(error $(build-host-vmlinuz) is unreadable. Please run: sudo chmod a+r $(build-host-vmlinuz) and try again))
+endif
 
 xen-create-image: xen linux buildroot | $(XEN_TMP)
 	cp $(KERNEL_IMAGE) $(XEN_TMP)


### PR DESCRIPTION
The readability check of the host kernel makes sense only when
XEN_BOOT=y, so avoid annoying users that are not concerned by this.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
