### PR TITLE
qemu_v8.mk: xen: pass -t ext4 instead of -t vfat to make-virt-fs

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -359,7 +359,7 @@ xen-create-image: xen linux buildroot | $(XEN_TMP)
 	cp $(XEN_IMAGE) $(XEN_TMP)
 	cp $(XEN_CFG) $(XEN_TMP)
 	cp $(ROOT)/out-br/images/rootfs.cpio.gz $(XEN_TMP)
-	virt-make-fs -t vfat $(XEN_TMP) $(XEN_EXT4)
+	virt-make-fs -t ext4 $(XEN_TMP) $(XEN_EXT4)
 
 xen-clean:
 	$(MAKE) -C $(XEN_PATH) clean


### PR DESCRIPTION
make-virt-fs is used to generate xen.ext4 but is passed '-t vfat'
instead of '-t ext4'. Fix that.

In fact 't -vfat' happens to be working in general, presumably because
the actual format of the image is detected at runtime. However, I could
not manage to make a VFAT image work in a Docker container based on
Ubuntu 21.04 and with the following kernel image package installed:

  linux-image-kvm/hirsute-updates,now 5.11.0.1009.9 amd64 [installed]

The error messages are as follows:

root@32b61ad4d7f3:~/optee_repo_qemu_v8/build# LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1 virt-make-fs -t vfat /root/optee_repo_qemu_v8/build/../out/bin/xen_files /root/optee_repo_qemu_v8/build/../out/bin/xen.ext4
[...]
libguestfs: trace: mount_options "utf8" "/dev/sda" "/"
guestfsd: => mkfs (0x116) took 0.47 secs
guestfsd: <= mount_options (0x4a) request length 68 bytes
commandrvf: stdout=n stderr=y flags=0x0
commandrvf: udevadm --debug settle -E /dev/sda
SELinux enabled state cached to: disabled
No filesystem is currently mounted on /sys/fs/cgroup.
Failed to determine unit we run in, ignoring: No data available
command: mount '-o' 'utf8' '/dev/sda' '/sysroot//'
[   11.673076] squashfs: Unknown parameter 'utf8'
[   11.694908] fuseblk: Unknown parameter 'utf8'
command: mount returned 32
command: mount: stderr:
mount: /sysroot: wrong fs type, bad option, bad superblock on /dev/sda, missing codepage or helper program, or other error.
ocaml_exn: 'mount_options' raised 'Failure' exception
guestfsd: error: mount exited with status 32: mount: /sysroot: wrong fs type, bad option, bad superblock on /dev/sda, missing codepage or helper program, or other error.
guestfsd: => mount_options (0x4a) took 0.40 secs
libguestfs: trace: mount_options = -1 (error)
libguestfs: error: mount_options: mount exited with status 32: mount: /sysroot: wrong fs type, bad option, bad superblock on /dev/sda, missing codepage or helper program, or other error.
libguestfs: trace: close
libguestfs: closing guestfs handle 0x55f423503430 (state 2)
[...]

With '-t ext4', the issue is gone.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
