### PR TITLE
Use security_model mapped-xattr for QEMU Persistent Secure Storage

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -425,7 +425,7 @@ QEMU_EXTRA_ARGS +=\
 	-device virtio-9p-device,fsdev=fsdev0,mount_tag=host
 ifeq ($(QEMU_PSS_ENABLE),y)
 QEMU_EXTRA_ARGS +=\
-	  -fsdev local,id=fsdev1,path=$(QEMU_PSS_HOST_DIR),security_model=none \
+	  -fsdev local,id=fsdev1,path=$(QEMU_PSS_HOST_DIR),security_model=mapped-xattr \
 	  -device virtio-9p-device,fsdev=fsdev1,mount_tag=secure
 endif
 endif


### PR DESCRIPTION
Use security_model mapped-xattr for QEMU_PSS_HOST_DIR.
This allows folders/files below /data/tee to be owned by
any uid/gid of the QEMU context.

Fixes https://github.com/OP-TEE/build/issues/478

Signed-off-by: Christoph Gellner <cgellner@de.adit-jv.com>
Suggested-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
