### PR TITLE
qemu_v8: xen: replace virt-make-fs with make_ext4fs

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -346,20 +346,13 @@ XEN_TMP ?= $(BINARIES_PATH)/xen_files
 $(XEN_TMP):
 	mkdir -p $@
 
-ifeq ($(XEN_BOOT),y)
-# virt-make-fs needs to be able to read the local kernel
-# See https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
-build-host-vmlinuz := $(shell echo /boot/vmlinuz-`uname -r`)
-$(if $(shell [ -r $(build-host-vmlinuz) ] || echo No), \
-  $(error $(build-host-vmlinuz) is unreadable. Please run: sudo chmod a+r $(build-host-vmlinuz) and try again))
-endif
-
 xen-create-image: xen linux buildroot | $(XEN_TMP)
 	cp $(KERNEL_IMAGE) $(XEN_TMP)
 	cp $(XEN_IMAGE) $(XEN_TMP)
 	cp $(XEN_CFG) $(XEN_TMP)
 	cp $(ROOT)/out-br/images/rootfs.cpio.gz $(XEN_TMP)
-	virt-make-fs -t ext4 $(XEN_TMP) $(XEN_EXT4)
+	rm -f $(XEN_EXT4)
+	mke2fs -t ext4 -d $(XEN_TMP) $(XEN_EXT4) 100M
 
 xen-clean:
 	$(MAKE) -C $(XEN_PATH) clean


### PR DESCRIPTION
Replaces virt-make-fs with make_ext4fs since its more robust on Ubuntu
and also a bit faster.

Fixes build problems like:
virt-make-fs -t ext4
/home/jens/work/repos/qemu_v8_xen/build/../out/bin/xen_files
/home/jens/work/repos/qemu_v8_xen/build/../out/bin/xen.ext4
Image Name:   Root file system
Created:      Wed Jun 30 19:34:06 2021
Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
Data Size:    31978230 Bytes = 31228.74 KiB = 30.50 MiB
Load Address: 44000000
Entry Point:  44000000
libguestfs: error: tar_in: tar subcommand failed on directory: /: tar:
./rootfs.cpio.gz: Wrote only 6144 of 10240 bytes
tar: Exiting with failure status due to previous errors
make: *** [Makefile:362: xen-create-image] Error 1

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
