### PR TITLE
qemu: export XEN_BOOT for make check

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -198,6 +198,7 @@ check: $(CHECK_DEPS)
 	cd $(BINARIES_PATH) && \
 		export QEMU=$(QEMU_BUILD)/arm-softmmu/qemu-system-arm && \
 		export QEMU_SMP=$(QEMU_SMP) && \
+		export XEN_BOOT=n && \
 		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \
 			echo "== $$PWD/serial0.log:"; \


### PR DESCRIPTION
```
qemu-check.exp needs the environment variable $XEN_BOOT to be set,
or the following error is displayed:
 $ make check
 ...
 # no such variable
     (read trace on "::env(XEN_BOOT)")
     invoked from within
 "if {$::env(XEN_BOOT) == "y"} {
         info " (Xen Dom0)"
 }"
     (file "/<...>/qemu-check.exp" line 119)

Signed-off-by: Jerome Forissier <jerome@forissier.org>
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
