### PR TITLE
br-ext: ftpm: fix recursive dependency on BR2_PACKAGE_OPTEE_OS_EXT

### DIFF
--- a/br-ext/package/ftpm_optee_ext/Config.in
+++ b/br-ext/package/ftpm_optee_ext/Config.in
@@ -1,6 +1,5 @@
 config BR2_PACKAGE_FTPM_OPTEE_EXT
        bool "Enable fTPM based on OPTEE"
-       depends on BR2_PACKAGE_OPTEE_OS_EXT
        select BR2_PACKAGE_OPTEE_OS_EXT
        help
          fTPM, http://github.com/microsoft/ms-tpm-20-ref.


### PR DESCRIPTION
Fix issue in ftpm_optee_ext/Config.in where BR2_PACKAGE_FTPM_OPTEE_EXT
both selects and depends on BR2_PACKAGE_OPTEE_OS_EXT. Keep only the
select rule.

The issue was found from a OP-TEE build using GCC-11. The build failed
with the following message:

build/br-ext/package/ftpm_optee_ext/Config.in:1:error: recursive dependency detected!
build/br-ext/package/ftpm_optee_ext/Config.in:1:	symbol BR2_PACKAGE_FTPM_OPTEE_EXT depends on BR2_PACKAGE_OPTEE_OS_EXT
build/br-ext/package/optee_os_ext/Config.in:1:	symbol BR2_PACKAGE_OPTEE_OS_EXT is selected by BR2_PACKAGE_FTPM_OPTEE_EXT

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
