### PR TITLE
hikey: fix 'invalid partition' error during recovery

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -348,6 +348,7 @@ recovery:
 	$(call flash_help)
 	@echo
 	$(ROOT)/burn-boot/hisi-idt.py --img1=$(LLOADER_PATH)/recovery.bin
+	fastboot getvar partition-size:ptable
 	fastboot flash loader $(LLOADER_PATH)/l-loader.bin
 	@echo
 	@echo "3. Wait until you see the (UART) message"


### PR DESCRIPTION
After trying to use upstream EDK2 on my HiKey board without success,
I reached a point where even 'make recovery' would not make the board
bootable again. The recovery process failed like so:

 $ make recovery
 [...]
 Waiting for device... [35][34][33][32][31][30][29][28][27][26][25][24][23][22][21][20][19][18]
 Sending /home/jerome/work/optee_repo_hikey/build/../l-loader/recovery.bin ...
 Done

 fastboot flash loader /home/jerome/work/optee_repo_hikey/build/../l-loader/l-loader.bin
 < waiting for any device >
 Sending 'loader' (39 KB)                           FAILED (remote: 'invalid partition')
 fastboot: error: Command failed
 make: *** [Makefile:351: recovery] Error 1

The solution to this problem is mentioned in [1] and consists in
running 'fastboot getvar partition-size:ptable' before the fastboot
flash command.

Link: [1] https://github.com/96boards/documentation/issues/751.
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
