### PR TITLE
[PR] fixup clang+llvm-12.x.x-x86_64-linux-gnu-ubuntu-16.04.tar.xz unzip into clang+llvm-12.x.x-x86_64-linux-gnu-ubuntu-

### DIFF
--- a/get_clang.sh
+++ b/get_clang.sh
@@ -27,14 +27,15 @@ if [ -e ${TMPDEST} ]; then
 fi
 
 function cleanup() {
-  rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
-  rm -rf ${AARCH64} ${ARMV7A}
+  # rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
+  # rm -rf ${AARCH64} ${ARMV7A} ${X86_64}
+  echo "clean up"
 }
 
 trap "{ exit 2; }" INT
 trap cleanup EXIT
 
-(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${X86_64}.tar.xz && tar xf ${X86_64}.tar.xz) &
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${X86_64}.tar.xz && mkdir ${X86_64} && tar xf ${X86_64}.tar.xz --strip-components 1 -C ${X86_64}) &
 pids=$!
 (wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${AARCH64}.tar.xz && tar xf ${AARCH64}.tar.xz) &
 pids="$pids $!"

--- a/get_clang.sh
+++ b/get_clang.sh
@@ -27,9 +27,8 @@ if [ -e ${TMPDEST} ]; then
 fi
 
 function cleanup() {
-  # rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
-  # rm -rf ${AARCH64} ${ARMV7A} ${X86_64}
-  echo "clean up"
+  rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
+  rm -rf ${AARCH64} ${ARMV7A}
 }
 
 trap "{ exit 2; }" INT

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -25,8 +25,7 @@ define dltc
 	@if [ ! -d "$(1)" ]; then \
 		mkdir -p $(1); \
 		echo "Downloading $(3) ..."; \
-		#curl -s -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz; \
-		wget -O $(TOOLCHAIN_ROOT)/$(3).tar.xz $(2);\
+		wget -O $(TOOLCHAIN_ROOT)/$(3).tar.xz $(2); \
 		tar xf $(TOOLCHAIN_ROOT)/$(3).tar.xz -C $(1) --strip-components=1; \
 		(cd $(1)/bin && for f in *-none-linux*; do ln -s $$f $${f//-none} ; done;) \
 	fi

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -25,7 +25,8 @@ define dltc
 	@if [ ! -d "$(1)" ]; then \
 		mkdir -p $(1); \
 		echo "Downloading $(3) ..."; \
-		curl -s -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz; \
+		#curl -s -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz; \
+		wget -O $(TOOLCHAIN_ROOT)/$(3).tar.xz $(2);\
 		tar xf $(TOOLCHAIN_ROOT)/$(3).tar.xz -C $(1) --strip-components=1; \
 		(cd $(1)/bin && for f in *-none-linux*; do ln -s $$f $${f//-none} ; done;) \
 	fi


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
Issue :
The clang+llvm-12.x.x-x86_64-linux-gnu-ubuntu-16.04.tar.xz will unzip by tar into clang+llvm-12.x.x-x86_64-linux-gnu-ubuntu- , instead of clang+llvm-12.x.x-x86_64-linux-gnu-ubuntu-16.04 , when run at line 46 (mv ${X86_64} ${TMPDEST} || exit 1) . we will get error.

