### PR TITLE
qemu, qemu_v8: Use telnet instead of custom soc_term

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -453,22 +453,19 @@ endef
 
 ifneq (, $(LAUNCH_TERMINAL))
 define launch-terminal
-	@nc -z  127.0.0.1 $(1) || \
-		$(LAUNCH_TERMINAL) "$(SOC_TERM_PATH)/soc_term $(1)" &
+	$(LAUNCH_TERMINAL) "telnet localhost $(1)"
 endef
 else
 gnome-terminal := $(shell command -v gnome-terminal 2>/dev/null)
 xterm := $(shell command -v xterm 2>/dev/null)
 ifdef gnome-terminal
 define launch-terminal
-	@nc -z  127.0.0.1 $(1) || \
-	$(gnome-terminal) -x $(SOC_TERM_PATH)/soc_term $(1) &
+	$(gnome-terminal) -- telnet localhost $(1)
 endef
 else
 ifdef xterm
 define launch-terminal
-	@nc -z  127.0.0.1 $(1) || \
-	$(xterm) -title $(2) -e $(BASH) -c "$(SOC_TERM_PATH)/soc_term $(1)" &
+	$(xterm) -title $(2) -e $(BASH) -c "telnet localhost $(1)"
 endef
 else
 check-terminal := @echo "Error: could not find gnome-terminal nor xterm" ; false
@@ -476,8 +473,9 @@ endif
 endif
 endif
 
-define wait-for-ports
-	@while ! nc -z 127.0.0.1 $(1) || ! nc -z 127.0.0.1 $(2); do sleep 1; done
+define launch-terminal-wait
+	@while ! nc -z localhost $(1); do sleep 1; done && \
+	$(call launch-terminal,$(1),$(2)) &
 endef
 
 ################################################################################

--- a/qemu.mk
+++ b/qemu.mk
@@ -24,16 +24,15 @@ BINARIES_PATH			?= $(ROOT)/out/bin
 U-BOOT_PATH			?= $(ROOT)/u-boot
 QEMU_PATH			?= $(ROOT)/qemu
 QEMU_BUILD			?= $(QEMU_PATH)/build
-SOC_TERM_PATH			?= $(ROOT)/soc_term
 
 DEBUG = 1
 
 ################################################################################
 # Targets
 ################################################################################
-all: arm-tf u-boot buildroot linux optee-os qemu soc-term
+all: arm-tf u-boot buildroot linux optee-os qemu
 clean: arm-tf-clean u-boot-clean buildroot-clean linux-clean optee-os-clean \
-	qemu-clean soc-term-clean check-clean
+	qemu-clean check-clean
 
 include toolchain.mk
 
@@ -148,15 +147,6 @@ optee-os: optee-os-common
 optee-os-clean: optee-os-clean-common
 
 ################################################################################
-# Soc-term
-################################################################################
-soc-term:
-	$(MAKE) -C $(SOC_TERM_PATH)
-
-soc-term-clean:
-	$(MAKE) -C $(SOC_TERM_PATH) clean
-
-################################################################################
 # Run targets
 ################################################################################
 .PHONY: run
@@ -171,12 +161,12 @@ run-only:
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(call check-terminal)
 	$(call run-help)
-	$(call launch-terminal,54320,"Normal World")
-	$(call launch-terminal,54321,"Secure World")
-	$(call wait-for-ports,54320,54321)
+	$(call launch-terminal-wait,54320,"Normal World")
+	$(call launch-terminal-wait,54321,"Secure World")
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/arm-softmmu/qemu-system-arm \
 		-nographic \
-		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-serial telnet:localhost:54320,server,nowait \
+		-serial telnet:localhost:54321,server,nowait \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on -cpu cortex-a15 \
 		-d unimp -semihosting-config enable=on,target=native \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -56,7 +56,6 @@ endif
 EDK2_BIN		?= $(EDK2_PATH)/Build/ArmVirtQemuKernel-$(EDK2_ARCH)/$(EDK2_BUILD)_$(EDK2_TOOLCHAIN)/FV/QEMU_EFI.fd
 QEMU_PATH		?= $(ROOT)/qemu
 QEMU_BUILD		?= $(QEMU_PATH)/build
-SOC_TERM_PATH		?= $(ROOT)/soc_term
 MODULE_OUTPUT		?= $(ROOT)/out/kernel_modules
 UBOOT_PATH		?= $(ROOT)/u-boot
 UBOOT_BIN		?= $(UBOOT_PATH)/u-boot.bin
@@ -100,9 +99,9 @@ endif
 ################################################################################
 # Targets
 ################################################################################
-TARGET_DEPS := arm-tf buildroot linux optee-os qemu soc-term
+TARGET_DEPS := arm-tf buildroot linux optee-os qemu
 TARGET_CLEAN := arm-tf-clean buildroot-clean linux-clean optee-os-clean \
-	qemu-clean soc-term-clean check-clean
+	qemu-clean check-clean
 
 TARGET_DEPS 		+= $(BL33_DEPS)
 
@@ -289,15 +288,6 @@ optee-os: optee-os-common
 optee-os-clean: optee-os-clean-common
 
 ################################################################################
-# Soc-term
-################################################################################
-soc-term:
-	$(MAKE) -C $(SOC_TERM_PATH)
-
-soc-term-clean:
-	$(MAKE) -C $(SOC_TERM_PATH) clean
-
-################################################################################
 # mkimage - create images to be loaded by U-Boot
 ################################################################################
 # Without the objcopy, the uImage will be 10x bigger.
@@ -383,12 +373,12 @@ run-only:
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(call check-terminal)
 	$(call run-help)
-	$(call launch-terminal,54320,"Normal World")
-	$(call launch-terminal,54321,"Secure World")
-	$(call wait-for-ports,54320,54321)
+	$(call launch-terminal-wait,54320,"Normal World")
+	$(call launch-terminal-wait,54321,"Secure World")
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 \
 		-nographic \
-		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-serial telnet:localhost:54320,server,nowait \
+		-serial telnet:localhost:54321,server,nowait \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on,gic-version=$(QEMU_GIC_VERSION),virtualization=$(QEMU_VIRT) \
 		-cpu cortex-a57 \


### PR DESCRIPTION
With this change, Qemu is the one that creates tcp ports and telnet will
listen on the created ports which is the opposite case when custom
soc_term application was used.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
