### PR TITLE
qemu, qemu_v8: set msize when mounting host filesystem

### DIFF
--- a/br-ext/board/qemu/post-build.sh
+++ b/br-ext/board/qemu/post-build.sh
@@ -31,13 +31,13 @@ fi
 
 if [[ $VIRTFS_AUTOMOUNT == "y" ]]; then
     grep host "$TARGETDIR"/etc/fstab > /dev/null || \
-    echo "host $VIRTFS_MOUNTPOINT 9p trans=virtio,version=9p2000.L,rw 0 0" >> "$TARGETDIR"/etc/fstab
+    echo "host $VIRTFS_MOUNTPOINT 9p trans=virtio,version=9p2000.L,msize=65536,rw 0 0" >> "$TARGETDIR"/etc/fstab
     echo "[+] shared directory mount added to fstab"
 fi
 
 if [[ $PSS_AUTOMOUNT == "y" ]]; then
     mkdir -p "$TARGETDIR"/data/tee
     grep secure "$TARGETDIR"/etc/fstab > /dev/null || \
-    echo "secure /data/tee 9p trans=virtio,version=9p2000.L,rw 0 0" >> "$TARGET_DIR"/etc/fstab
+    echo "secure /data/tee 9p trans=virtio,version=9p2000.L,msize=65536,rw 0 0" >> "$TARGET_DIR"/etc/fstab
     echo "[+] persistent secure storage mount added to fstab"
 fi


### PR DESCRIPTION
When VIRTFS_AUTOMOUNT=y and/or PSS_AUTOMOUNT=y, QEMU prints the
following warning:

 qemu-system-aarch64: warning: 9p: degraded performance: a reasonable
 high msize should be chosen on client/guest side (chosen msize is <=
 8192). See https://wiki.qemu.org/Documentation/9psetup#msize for
 details.

Let's set the buffer size to 64K mainly to silence this warning. The
performance is noticeably increased too although it doesn't really
matters for typical OP-TEE use cases.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
