### PR TITLE
linux-defconfig: explicit compile flag usage

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -376,6 +376,7 @@ linux-common: linux-defconfig
 $(LINUX_PATH)/.config: $(LINUX_DEFCONFIG_COMMON_FILES)
 	cd $(LINUX_PATH) && \
 		ARCH=$(LINUX_DEFCONFIG_COMMON_ARCH) \
+		CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
 		scripts/kconfig/merge_config.sh $(LINUX_DEFCONFIG_COMMON_FILES) \
 			$(LINUX_DEFCONFIG_BENCH)
 


### PR DESCRIPTION
Current linux config file generation does not add the cross compilation
flags, leading potentially to compilation errors. Not sure how a proper config
file is generated with current implementation but issues are observerd
specially when buildling the linux image with a single thread.

Signed-off-by: Ibai Erkiaga <ibai.erkiaga-elorza@xilinx.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
