### PR TITLE
qemu: do not force kernel CONFIG_PREEMPT=y

### DIFF
--- a/kconfigs/qemu.conf
+++ b/kconfigs/qemu.conf
@@ -1,8 +1,5 @@
 CONFIG_TEE=y
 CONFIG_OPTEE=y
-### Enabling PREEMPT prevents random failures of
-### "make check" in Travis CI
-CONFIG_PREEMPT=y
 ### Enable 9P VFS
 CONFIG_NET_9P=y
 CONFIG_NET_9P_VIRTIO=y


### PR DESCRIPTION
Since Linux commit dcb3b06d9c34 ("tee: optee: replace might_sleep with
cond_resched") in v5.11, setting CONFIG_PREEMPT=y in kconfigs/qemu.conf
is not needed anymore. It was a workaround for the missing call to
cond_resched() in the TEE driver. At that time, might_sleep() together
with preemption enabled allowed to get rid of some RCU warning messages
when running long operations in secure world such as large key generation
(test case: "xtest -l 1 4007_rsa"). With cond_resched() the preemption
settings do not matter anymore.

As a result of this change, QEMUv8 is unmodified (CONFIG_PREEMPT=y is
set by default in the kernel's arch/arm64/configs/defconfig), but 32-bit
QEMU now has CONFIG_PREEMPT disabled. Both platforms are tested and
4007_rsa runs as expected with no warning.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
