### PR TITLE
optee_rust_examples_ext.mk: remove extra space in PATH

### DIFF
--- a/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
+++ b/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
@@ -15,7 +15,7 @@ export OPTEE_DIR = $(@D)/../../..
 export OPTEE_OS_DIR = $(OPTEE_DIR)/optee_os
 export OPTEE_CLIENT_DIR = $(OPTEE_DIR)/out-br/build/optee_client_ext-1.0
 export OPTEE_CLIENT_INCLUDE = $(OPTEE_CLIENT_DIR)/out/export/usr/include
-export PATH += :$(OPTEE_DIR)/toolchains/aarch64/bin
+export PATH := $(PATH):$(OPTEE_DIR)/toolchains/aarch64/bin
 export VENDOR = qemu_v8.mk
 export OPTEE_OS_INCLUDE = $(OPTEE_DIR)/optee_os/out/arm/export-ta_arm64/include
 


### PR DESCRIPTION
When upgrading from Buildroot 2021.2 to 2021.08, the following error
occurs:

 $ make buildroot
 ...
   GEN     /home/jerome/work/optee_repo_qemu_v8/out-br/Makefile

 Your PATH contains spaces, TABs, and/or newline (\n) characters.
 This doesn't work. Fix you PATH.
 make[1]: *** [Makefile:23: _all] Error 2
 make[1]: Leaving directory '/home/jerome/work/optee_repo_qemu_v8/out-br'
 make: *** [common.mk:323: buildroot] Error 2

The space comes from the line that appends the toolchain to the PATH in
optee_rust_examples_ext.mk. Fix it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
