### PR TITLE
common.mk: fix cargo error when building Rust examples

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -281,7 +281,7 @@ ifeq ($(OPTEE_RUST_ENABLE),y)
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT ?= y
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_CROSS_COMPILE ?= $(CROSS_COMPILE_S_USER)
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_SITE ?= $(OPTEE_RUST_PATH)
-BR2_PACKAGE_OPTEE_RUST_EXAMPLES_TC_PATH_ENV = $(PATH):$(ROOT)/toolchains/aarch64/bin
+BR2_PACKAGE_OPTEE_RUST_EXAMPLES_TC_PATH_ENV = $(PATH):$(ROOT)/toolchains/aarch64/bin:$(HOME)/.cargo/bin
 endif
 # The OPTEE_OS package builds nothing, it just installs files into the
 # root FS when applicable (for example: shared libraries)
@@ -333,7 +333,7 @@ buildroot: optee-os optee-rust
 		$(DEFCONFIG_FTPM) \
 		--br-defconfig out-br/extra.conf \
 		--make-cmd $(MAKE))
-	@$(OPTEE_RUST_SET_ENV) $(MAKE) -C ../out-br all
+	@$(MAKE) -C ../out-br all
 
 .PHONY: buildroot-clean
 buildroot-clean:
@@ -518,7 +518,6 @@ optee-os-clean-common:
 optee-rust:
 ifeq ($(OPTEE_RUST_ENABLE),y)
 	@(cd $(OPTEE_RUST_PATH) && ./setup.sh)
-OPTEE_RUST_SET_ENV = source ~/.cargo/env &&
 endif
 
 ################################################################################


### PR DESCRIPTION
"cargo: command not found" occurs when building Rust examples.
"source ~/.cargo/bin" doesn't work in some environments. Replace
that with adding the PATH.

Signed-off-by: Yuan Zhuang <zhuangyuan04@baidu.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
