### PR TITLE
Disable CXX tests when building via buildroot toolchain

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -259,6 +259,9 @@ BUILDROOT_TOOLCHAIN=toolchain-aarch$(COMPILE_NS_USER)-legacy
 endif
 else
 BUILDROOT_TOOLCHAIN=toolchain-aarch$(COMPILE_NS_USER)-sdk
+# CXX tests fails to build with buildroot toolchain, disable them until
+# a proper fix is found.
+WITH_CXX_TESTS := n
 endif
 endif
 


### PR DESCRIPTION
Error observed with buildroot toolchain on Arm64 host machine:
  CC      out/init.o
  CC      out/os_test.o
  CC      out/ta_entry.o
  CXX     out/cxx_tests.o
  CC      out/user_ta_header.o
  CPP     out/ta.lds
  LD      out/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf
/home/sumit/optee_br/build/../toolchains/aarch64/bin/aarch64-linux-ld.bfd: /home/sumit/optee_br/toolchains/aarch64/bin/../lib/gcc/aarch64-buildroot-linux-gnu/10.3.0/../../../../aarch64-buildroot-linux-gnu/lib/../lib64/libstdc++.a(cp-demangle.o): in function `d_append_num':
cp-demangle.c:(.text+0x830): undefined reference to `__sprintf_chk'
make[3]: *** [/home/sumit/optee_br/optee_os/out/arm/export-ta_arm64/mk/link.mk:117: out/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf] Error 1
make[2]: *** [package/pkg-generic.mk:271: /home/sumit/optee_br/out-br/build/optee_test_ext-1.0/.stamp_built] Error 2
make[1]: *** [Makefile:23: _all] Error 2
make[1]: Leaving directory '/home/sumit/optee_br/out-br'
make: *** [common.mk:324: buildroot] Error 2

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
