### PR TITLE
GitHub actions: General updates

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -3,15 +3,22 @@ on:
   schedule:
   - cron: "15 00 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v4.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed pull request at any time.'
-        exempt-issue-label: 'bug'
+        exempt-issue-label: bug,enhancement
+        exempt-pr-label: bug,enhancement
         days-before-stale: 30
         days-before-close: 5
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true


### PR DESCRIPTION
- Update 'stale' from v1.0 to v4.0.1.
- Give 'write' permissions to actions (pull requests and issues).
- Add 'enhancement' to 'exempt-issue-label', so we that stale doesn't
  automatically close issues and pr's with the 'enhancement' label.
- Add 'exempt-pr-label' to match exempt-issue-label'.
- Add and set (to true)
    remove-issue-stale-when-updated
    remove-pr-stale-when-updated
  which will automatically remove the 'Stale' label when someone adds a
  new comment to a ticket marked as stale.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>