### PR TITLE
GitHub actions: fix runtime warning

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -16,8 +16,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed pull request at any time.'
-        exempt-issue-label: bug,enhancement
-        exempt-pr-label: bug,enhancement
+        exempt-issue-labels: bug,enhancement
+        exempt-pr-labels: bug,enhancement
         days-before-stale: 30
         days-before-close: 5
         remove-issue-stale-when-updated: true


### PR DESCRIPTION
When running the GitHub action, there is a warning:
  Unexpected input(s) 'exempt-issue-label', 'exempt-pr-label', valid
  inputs are ... 'exempt-issue-labels', 'exempt-pr-labels'.

Add the missing 's' to labels to fix the issue.

This is a new warning after upgrading to the 'Stale' action to v4.1.0,
so they must have changed to the plural version in more recent versions.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
