### PR TITLE
toolchain: Add optimizations for aarch64 host

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -108,11 +108,15 @@ QEMU_VIRTFS_MOUNTPOINT	?= /mnt/host
 ifeq ($(COMPILE_NS_USER),64)
 ifeq ($(UNAME_M),x86_64)
 MULTIARCH			:= aarch64-linux-gnu
+else ifeq ($(UNAME_M),aarch64)
+MULTIARCH			:= aarch64-linux
 else
 MULTIARCH			:= aarch64-linux
 endif
 else
 ifeq ($(UNAME_M),x86_64)
+MULTIARCH			:= arm-linux-gnueabihf
+else ifeq ($(UNAME_M),aarch64)
 MULTIARCH			:= arm-linux-gnueabihf
 else
 MULTIARCH			:= arm-linux
@@ -256,6 +260,12 @@ ifeq ($(COMPILE_LEGACY),)
 BUILDROOT_TOOLCHAIN=toolchain-aarch$(COMPILE_NS_USER)
 else
 BUILDROOT_TOOLCHAIN=toolchain-aarch$(COMPILE_NS_USER)-legacy
+endif
+else ifeq ($(UNAME_M),aarch64)
+ifeq ($(COMPILE_NS_USER),64)
+BUILDROOT_TOOLCHAIN=toolchain-aarch64-sdk
+else
+BUILDROOT_TOOLCHAIN=toolchain-aarch32
 endif
 else
 BUILDROOT_TOOLCHAIN=toolchain-aarch$(COMPILE_NS_USER)-sdk

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -6,17 +6,6 @@ ROOT				?= $(CURDIR)/..
 TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 UNAME_M				:= $(shell uname -m)
 
-ifeq ($(UNAME_M),x86_64)
-AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
-AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
-AARCH32_GCC_VERSION 		?= gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf
-SRC_AARCH32_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/$(AARCH32_GCC_VERSION).tar.xz
-
-AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
-AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
-AARCH64_GCC_VERSION 		?= gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu
-SRC_AARCH64_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/$(AARCH64_GCC_VERSION).tar.xz
-
 # Download toolchain macro for saving some repetition
 # $(1) is $AARCH.._PATH		: i.e., path to the destination
 # $(2) is $SRC_AARCH.._GCC	: is the downloaded tar.gz file
@@ -33,6 +22,37 @@ define dltc
 		(cd $(1)/bin && for f in *-none-linux*; do ln -s $$f $${f//-none} ; done;) \
 	fi
 endef
+
+# Build buildroot toolchain macro for saving some repetition
+# $(1) is $ARCH			: target architecture
+# $(2) is $AARCH.._PATH		: i.e., path to the destination
+# $(3) & $(4)			: parts of toolchain target triplet
+define build_toolchain
+	@echo Building $1 toolchain
+	@mkdir -p ../out-$1-sdk $2
+	@(cd .. && python build/br-ext/scripts/make_def_config.py \
+		--br buildroot --out out-$1-sdk --br-ext build/br-ext \
+		--top-dir "$(ROOT)" \
+		--br-defconfig build/br-ext/configs/sdk-$1 \
+		--br-defconfig build/br-ext/configs/sdk-common \
+		--make-cmd $(MAKE))
+	@$(MAKE) -C ../out-$1-sdk clean
+	@$(MAKE) -C ../out-$1-sdk sdk
+	@tar xf ../out-$1-sdk/images/$3-buildroot-linux-$4_sdk-buildroot.tar.gz \
+		-C $2 --strip-components=1
+	@touch $2/.done
+endef
+
+ifeq ($(UNAME_M),x86_64)
+AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
+AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
+AARCH32_GCC_VERSION 		?= gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf
+SRC_AARCH32_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/$(AARCH32_GCC_VERSION).tar.xz
+
+AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
+AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
+AARCH64_GCC_VERSION 		?= gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu
+SRC_AARCH64_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/$(AARCH64_GCC_VERSION).tar.xz
 
 .PHONY: toolchains
 toolchains: aarch32 aarch64
@@ -61,7 +81,32 @@ endef
 clang-toolchains:
 	$(call dl-clang,$(CLANG_VER),$(CLANG_PATH))
 
-else # $(UNAME_M) != x86_64
+else ifeq ($(UNAME_M),aarch64)
+
+AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
+AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
+AARCH32_GCC_VERSION 		?= gcc-arm-10.2-2020.11-aarch64-arm-none-linux-gnueabihf
+SRC_AARCH32_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/$(AARCH32_GCC_VERSION).tar.xz
+
+# There isn't any native aarch64 toolchain released from Arm and buildroot
+# doesn't support distribution toolchain [1]. So we are left with no choice
+# but to build buildroot toolchain from source and use it.
+#
+# [1] https://buildroot.org/downloads/manual/manual.html#_cross_compilation_toolchain
+AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
+AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-
+
+.PHONY: toolchains
+toolchains: aarch32 $(AARCH64_PATH)/.done
+
+.PHONY: aarch32
+aarch32:
+	$(call dltc,$(AARCH32_PATH),$(SRC_AARCH32_GCC),$(AARCH32_GCC_VERSION))
+
+$(AARCH64_PATH)/.done:
+	$(call build_toolchain,aarch64,$(AARCH64_PATH),aarch64,gnu)
+
+else # $(UNAME_M) != x86_64 or $(UNAME_M) != aarch64
 AARCH32_PATH 			:= $(TOOLCHAIN_ROOT)/aarch32
 AARCH32_CROSS_COMPILE 		:= $(AARCH32_PATH)/bin/arm-linux-
 AARCH64_PATH 			:= $(TOOLCHAIN_ROOT)/aarch64
@@ -69,22 +114,6 @@ AARCH64_CROSS_COMPILE 		:= $(AARCH64_PATH)/bin/aarch64-linux-
 
 .PHONY: toolchains
 toolchains: $(AARCH64_PATH)/.done $(AARCH32_PATH)/.done
-
-define build_toolchain
-	@echo Building $1 toolchain
-	@mkdir -p ../out-$1-sdk $2
-	@(cd .. && python build/br-ext/scripts/make_def_config.py \
-		--br buildroot --out out-$1-sdk --br-ext build/br-ext \
-		--top-dir "$(ROOT)" \
-		--br-defconfig build/br-ext/configs/sdk-$1 \
-		--br-defconfig build/br-ext/configs/sdk-common \
-		--make-cmd $(MAKE))
-	@$(MAKE) -C ../out-$1-sdk clean
-	@$(MAKE) -C ../out-$1-sdk sdk
-	@tar xf ../out-$1-sdk/images/$3-buildroot-linux-$4_sdk-buildroot.tar.gz \
-		-C $2 --strip-components=1
-	@touch $2/.done
-endef
 
 $(AARCH64_PATH)/.done:
 	$(call build_toolchain,aarch64,$(AARCH64_PATH),aarch64,gnu)


### PR DESCRIPTION
Lets switch over to using aarch64 hosted cross-compiler for aarch32
rather than building toochain for aarch32 from source which is very
combersome. But in case of native build for aarch64 on aarch64 host we
are left with no choice but to use buildroot toolchain as Arm doesn't
provide binary toolchain releases for aarch64 native compiler.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
