### PR TITLE
qemu_v8: add support for EL3 SPMC

### DIFF
--- a/qemu_v8/spmc_el3_manifest.dts
+++ b/qemu_v8/spmc_el3_manifest.dts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020-2021, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/dts-v1/;
+
+#define MODE_EL1	(0x1)
+
+/* For consumption by EL3 SPMC. */
+/ {
+	compatible = "arm,ffa-manifest-1.0";
+	#address-cells = <2>;
+	#size-cells = <1>;
+
+	ffa-version = <0x00010000>; /* 31:16 - Major, 15:0 - Minor */
+	id = <0x8001>;
+	uuid = <0xe0786148 0xe311f8e7 0x02005ebc 0x1bc5d5a5>;
+	messaging-method = <1>; /* Direct Messaging Only */
+	exception-level = <MODE_EL1>;
+	execution-state = <0>;
+	execution-ctx-count = <8>;
+	gp-register-num = <0>;
+	power-management-messages = <0x1>; /* Subscribe to CPU_OFF PM Msgs */
+};


### PR DESCRIPTION
Please wait with this until after the release.

Adds support for building TF-A and OP-TEE the SPMC at EL3.

A special manifest is added to be consumed by the SPMC.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Needed by https://github.com/OP-TEE/optee_os/pull/5141

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
