### PR TITLE
qemu_v8: Introducing PAUTH option

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -50,6 +50,9 @@ ifneq ($(filter-out n 1,$(SPMC_AT_EL)),)
 $(error Unsupported SPMC_AT_EL value $(SPMC_AT_EL))
 endif
 
+# Option to configure Pointer Authentication for TA's
+PAUTH ?= n
+
 ################################################################################
 # Paths to git projects and various binaries
 ################################################################################
@@ -171,6 +174,10 @@ TF_A_FLAGS += \
 	MBEDTLS_DIR=$(ROOT)/mbedtls \
 	TRUSTED_BOARD_BOOT=1 \
 	GENERATE_COT=1
+endif
+
+ifeq ($(PAUTH),y)
+TF_A_FLAGS += CTX_INCLUDE_PAUTH_REGS=1
 endif
 
 arm-tf: optee-os $(BL33_DEPS)
@@ -296,6 +303,10 @@ OPTEE_OS_COMMON_FLAGS_SPMC_AT_EL_1 = CFG_CORE_SEL1_SPMC=y
 
 ifeq ($(XEN_BOOT),y)
 OPTEE_OS_COMMON_FLAGS += CFG_VIRTUALIZATION=y
+endif
+
+ifeq ($(PAUTH),y)
+OPTEE_OS_COMMON_FLAGS += CFG_TA_PAUTH=y
 endif
 
 OPTEE_OS_COMMON_FLAGS += $(OPTEE_OS_COMMON_FLAGS_SPMC_AT_EL_$(SPMC_AT_EL))


### PR DESCRIPTION
Introduces option PAUTH, which can be used to enable
Pointer Authentication for TA's.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
