### PR TITLE
imx: add missing linux dependency for flash-image

### DIFF
--- a/imx.mk
+++ b/imx.mk
@@ -214,7 +214,7 @@ FLASH_IMAGE_SIZE := $(shell echo $$(( $(FLASH_IMAGE_SIZE) + $(FLASH_PARTITION_RO
 endif
 
 .PHONY: flash-image
-flash-image: buildroot mkimage
+flash-image: buildroot mkimage linux
 	$(MAKE) flash-image-only
 
 .PHONY: flash-image-only


### PR DESCRIPTION
Adds a missing linux dependency for the flash-image target.

This should fix erros like:
  CC [M]  drivers/gpu/drm/nouveau/nvkm/subdev/i2c/bus.o
mformat -i .../build/../out/boot.img.fat -n 64 -h 255 -T 131072 -v "BOOT IMG" -C ::
mcopy -i .../build/../out/boot.img.fat .../build/../linux/arch/arm64/boot/Image ::
.../build/../linux/arch/arm64/boot/Image: No such file or directory

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
