### PR TITLE
qemu_v8: Add support for measured boot with swtpm

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -464,6 +464,16 @@ endif
 QEMU_EXTRA_ARGS +=\
 	-netdev user,id=vmnic$(HOSTFWD) -device virtio-net-device,netdev=vmnic
 
+SWTPM_CMD = 'rm -rf $(SWTPM_TMP_DIR); mkdir -p $(SWTPM_TMP_DIR); swtpm_setup --tpmstate $(SWTPM_TMP_DIR) --tpm2 --pcr-banks $(ALGO); exec swtpm socket --tpmstate dir=$(SWTPM_TMP_DIR) --ctrl type=unixio,path=$(SWTPM_TMP_DIR)/swtpm-sock --log level=40 --tpm2'
+
+define run-swtpm-help
+	@echo
+	@echo \* swtpm needs to be launched, else qemu will stop with error
+	@echo \* Install swtpm
+	@echo \* Run the cmd below in a separate terminal
+	@echo $(SWTPM_CMD)
+endef
+
 define run-help
 	@echo
 	@echo \* QEMU is now waiting to start the execution


### PR DESCRIPTION
To enable measured boot support in TF-A and OP-TEE, use option
MEASURED_BOOT=y

By default this assumes we are using swtpm as the backend, so swtpm
needs to be installed in the system.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
