### PR TITLE
optee-rust: fix building errors

### DIFF
--- a/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
+++ b/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
@@ -21,6 +21,7 @@ export OPTEE_CLIENT_DIR = $(OPTEE_DIR)/out-br/build/optee_client_ext-1.0
 export OPTEE_CLIENT_INCLUDE = $(OPTEE_CLIENT_DIR)/out/export/usr/include
 export VENDOR = qemu_v8.mk
 export OPTEE_OS_INCLUDE = $(OPTEE_DIR)/optee_os/out/arm/export-ta_arm64/include
+export CC = $(OPTEE_DIR)/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
 
 define OPTEE_RUST_EXAMPLES_EXT_BUILD_CMDS
 	@$(foreach f,$(wildcard $(@D)/examples/*/Makefile), \

--- a/common.mk
+++ b/common.mk
@@ -533,7 +533,7 @@ optee-os-clean-common:
 .PHONY: optee-rust
 optee-rust:
 ifeq ($(OPTEE_RUST_ENABLE),y)
-	@(cd $(OPTEE_RUST_PATH) && ./setup.sh)
+	@(export OPTEE_DIR=$(ROOT) && cd $(OPTEE_RUST_PATH) && ./setup.sh)
 endif
 
 ################################################################################


### PR DESCRIPTION
Hi,
Teaclave TrustZone SDK 0.2.0 is released and the release note is in https://github.com/apache/incubator-teaclave-trustzone-sdk/releases/tag/v0.2.0.
Besides the release there are some fixes and updates, so `optee-rust` in OP-TEE repo is expected to be pinned to https://github.com/apache/incubator-teaclave-trustzone-sdk/commit/3272b38b013395e3376a38af6315633239d26c1c. I've opened a PR:https://github.com/OP-TEE/manifest/pull/211.
In the new version of Teaclave TrustZone SDK, OPTEE_DIR is checked in setup.sh. If OPTEE_DIR is not set, it will download OP-TEE source code. So set OPTEE_DIR as the directory of OP-TEE repo.

Best Regards,
Yuan

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
