### PR TITLE
hikey: generate only one of linux-4g and linux-8g

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -300,7 +300,7 @@ lloader: arm-tf atf-fb
 		ln -sf $(TF_A_PATH)/build/hikey/$(TF_A_BUILD)/bl1.bin && \
 		ln -sf $(TF_A_PATH)/build/hikey/$(TF_A_BUILD)/bl2.bin && \
 		ln -sf $(ATF_FB_PATH)/build/hikey/$(ATF_FB_BUILD)/bl1.bin fastboot.bin && \
-		$(MAKE) hikey PTABLE_LST="linux-8g linux-4g" CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
+		$(MAKE) hikey PTABLE_LST="linux-$(CFG_FLASH_SIZE)g" CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 
 .PHONY: lloader-clean
 lloader-clean:


### PR DESCRIPTION
CFG_FLASH_SIZE can be used to generate only linux-4g or linux-8g instead
of both.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
