### PR TITLE
tf-a/qemu v8: Change LOG_LEVEL to 40 when DEBUG=1

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -146,7 +146,7 @@ ifeq ($(TF_A_DEBUG),0)
 TF_A_LOGLVL ?= 30
 TF_A_OUT = $(TF_A_PATH)/build/qemu/release
 else
-TF_A_LOGLVL ?= 50
+TF_A_LOGLVL ?= 40
 TF_A_OUT = $(TF_A_PATH)/build/qemu/debug
 endif
 


### PR DESCRIPTION
With LOG_LEVEL=50 and DEBUG=1, BL31 becomes too big, with LOG_LEVEL=40
we will miss a few debug prints, but it will at produce a valid binary
and more importantly, you'll get an elf-file with all debug symbols,
i.e., it's GDB makes up for the missing prints.

(FWIW, there is a compiler error with `50` as well, I'll send a fix for that to TF-A)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
