### PR TITLE
xen: add upstream patch to fix OPTEE_SMC_DISABLE_SHM_CACHE

### DIFF
--- a/br-ext/patches/xen/0001-xen-arm-optee-Fix-arm_smccc_smc-s-a0-for-OPTEE_SMC_D.patch
+++ b/br-ext/patches/xen/0001-xen-arm-optee-Fix-arm_smccc_smc-s-a0-for-OPTEE_SMC_D.patch
@@ -1,0 +1,40 @@
+From 1c3ed9c908732d19660fbe83580674d585464d4c Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Mon, 27 Sep 2021 16:54:10 +0300
+Subject: [PATCH] xen/arm: optee: Fix arm_smccc_smc's a0 for
+ OPTEE_SMC_DISABLE_SHM_CACHE
+
+Fix a possible copy-paste error in arm_smccc_smc's first argument (a0)
+for OPTEE_SMC_DISABLE_SHM_CACHE case.
+
+This error causes Linux > v5.14-rc5 (b5c10dd04b7418793517e3286cde5c04759a86de
+optee: Clear stale cache entries during initialization) to stuck
+repeatedly issuing OPTEE_SMC_DISABLE_SHM_CACHE call and waiting for
+the result to be OPTEE_SMC_RETURN_ENOTAVAIL which will never happen.
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Reviewed-by: Bertrand Marquis <bertrand.marquis@arm.com>
+Reviewed-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Acked-by: Stefano Stabellini <sstabellini@kernel.org>
+Fixes: 2e35cdf9b2ca ("xen/arm: optee: add OP-TEE mediator skeleton")
+Backport: 4.13+
+---
+ xen/arch/arm/tee/optee.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/arch/arm/tee/optee.c b/xen/arch/arm/tee/optee.c
+index 345361566e..6df0d44eb9 100644
+--- a/xen/arch/arm/tee/optee.c
++++ b/xen/arch/arm/tee/optee.c
+@@ -1692,7 +1692,7 @@ static bool optee_handle_call(struct cpu_user_regs *regs)
+         return true;
+ 
+     case OPTEE_SMC_DISABLE_SHM_CACHE:
+-        arm_smccc_smc(OPTEE_SMC_ENABLE_SHM_CACHE, 0, 0, 0, 0, 0, 0,
++        arm_smccc_smc(OPTEE_SMC_DISABLE_SHM_CACHE, 0, 0, 0, 0, 0, 0,
+                       OPTEE_CLIENT_ID(current->domain), &resp);
+         set_user_reg(regs, 0, resp.a0);
+         if ( resp.a0 == OPTEE_SMC_RETURN_OK ) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Adds a Xen bug fix from upstream [1]. With this we will be able to get
rid of a revert in the linux kernel [2].

Link: [1] https://github.com/xen-project/xen/commit/1c3ed9c908732d19660fbe83580674d585464d4c
Link: [2] https://github.com/linaro-swg/linux/commit/665750f493d3fcf307952f19c0442c092b76d852
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
