### PR TITLE
optee-rust: prevent new execution after successful build

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -534,10 +534,15 @@ optee-os-clean-common:
 # OP-TEE Rust
 ################################################################################
 .PHONY: optee-rust
-optee-rust:
+optee-rust: $(OPTEE_RUST_PATH)/.done
+
+$(OPTEE_RUST_PATH)/.done:
 ifeq ($(OPTEE_RUST_ENABLE),y)
-	@(export OPTEE_DIR=$(ROOT) && cd $(OPTEE_RUST_PATH) && ./setup.sh)
+	@(export OPTEE_DIR=$(ROOT) && cd $(OPTEE_RUST_PATH) && ./setup.sh && touch .done)
 endif
+
+optee-rust-clean:
+	rm -f $(OPTEE_RUST_PATH)/.done
 
 ################################################################################
 # fTPM Rules


### PR DESCRIPTION
"make optee-rust OPTEE_RUST_ENABLE=y" always runs the setup.sh script
in $(ROOT)/optee_rust. The script clones about 600 MB of data. That
can't be done each time especially since the check-rust target depends
on optee-rust.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
