### PR TITLE
xen: add patch to support OPTEE_SMC_SEC_CAP_MEMREF_NULL

### DIFF
--- a/br-ext/patches/xen/0001-optee-enable-OPTEE_SMC_SEC_CAP_MEMREF_NULL-capabilit.patch
+++ b/br-ext/patches/xen/0001-optee-enable-OPTEE_SMC_SEC_CAP_MEMREF_NULL-capabilit.patch
@@ -1,0 +1,71 @@
+From d4fb5f166c2bfbaf9ba0de69da0d411288f437a9 Mon Sep 17 00:00:00 2001
+From: Volodymyr Babchuk <Volodymyr_Babchuk@epam.com>
+Date: Fri, 7 May 2021 01:39:47 +0000
+Subject: [PATCH] optee: enable OPTEE_SMC_SEC_CAP_MEMREF_NULL capability
+
+OP-TEE mediator already have support for NULL memory references. It
+was added in patch 0dbed3ad336 ("optee: allow plain TMEM buffers with
+NULL address"). But it does not propagate
+OPTEE_SMC_SEC_CAP_MEMREF_NULL capability flag to a guest, so well
+behaving guest can't use this feature.
+
+Note: linux optee driver honors this capability flag when handling
+buffers from userspace clients, but ignores it when working with
+internal calls. For instance, __optee_enumerate_devices() function
+uses NULL argument to get buffer size hint from OP-TEE. This was the
+reason, why "optee: allow plain TMEM buffers with NULL address" was
+introduced in the first place.
+
+This patch adds the mentioned capability to list of known
+capabilities. From Linux point of view it means that userspace clients
+can use this feature, which is confirmed by OP-TEE test suite:
+
+* regression_1025 Test memref NULL and/or 0 bytes size
+o regression_1025.1 Invalid NULL buffer memref registration
+  regression_1025.1 OK
+o regression_1025.2 Input/Output MEMREF Buffer NULL - Size 0 bytes
+  regression_1025.2 OK
+o regression_1025.3 Input MEMREF Buffer NULL - Size non 0 bytes
+  regression_1025.3 OK
+o regression_1025.4 Input MEMREF Buffer NULL over PTA invocation
+  regression_1025.4 OK
+  regression_1025 OK
+
+Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Acked-by: Julien Grall <jgrall@amazon.com>
+---
+ xen/arch/arm/tee/optee.c            | 3 ++-
+ xen/include/asm-arm/tee/optee_smc.h | 3 +++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/xen/arch/arm/tee/optee.c b/xen/arch/arm/tee/optee.c
+index 980eebe847..345361566e 100644
+--- a/xen/arch/arm/tee/optee.c
++++ b/xen/arch/arm/tee/optee.c
+@@ -96,7 +96,8 @@
+ #define OPTEE_KNOWN_NSEC_CAPS OPTEE_SMC_NSEC_CAP_UNIPROCESSOR
+ #define OPTEE_KNOWN_SEC_CAPS (OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM | \
+                               OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM | \
+-                              OPTEE_SMC_SEC_CAP_DYNAMIC_SHM)
++                              OPTEE_SMC_SEC_CAP_DYNAMIC_SHM | \
++                              OPTEE_SMC_SEC_CAP_MEMREF_NULL)
+ 
+ enum optee_call_state {
+     OPTEE_CALL_NORMAL,
+diff --git a/xen/include/asm-arm/tee/optee_smc.h b/xen/include/asm-arm/tee/optee_smc.h
+index d568bb2fe1..2f5c702326 100644
+--- a/xen/include/asm-arm/tee/optee_smc.h
++++ b/xen/include/asm-arm/tee/optee_smc.h
+@@ -244,6 +244,9 @@
+  */
+ #define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		(1 << 2)
+ 
++/* Secure world supports Shared Memory with a NULL reference */
++#define OPTEE_SMC_SEC_CAP_MEMREF_NULL		(1 << 4)
++
+ #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
+ #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
+ 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)
+-- 
+2.34.1
+


### PR DESCRIPTION
Adds Xen upstream patch "optee: enable OPTEE_SMC_SEC_CAP_MEMREF_NULL
capability" in order to avoid failures in the GlobalPlatform test
suite [2]:

 optee/build $ export GP_PACKAGE=~/work/TEE_Initial_Configuration-Test_Suite_v2_0_0_2-2017_06_09.7z
 optee/build $ make -j10 XEN_BOOT=y run
 ...
 $ xtest gp_
 ...
 gp_10081 FAILED first error at gp_10000.c:1653
 gp_10082 FAILED first error at gp_10000.c:1673
 gp_10083 FAILED first error at gp_10000.c:1693
 gp_10155 FAILED first error at gp_10000.c:3346
 gp_10156 FAILED first error at gp_10000.c:3366
 gp_10157 FAILED first error at gp_10000.c:3386
 gp_10229 FAILED first error at gp_10000.c:5039
 gp_10230 FAILED first error at gp_10000.c:5059
 gp_10231 FAILED first error at gp_10000.c:5079
 gp_10303 FAILED first error at gp_10000.c:6732
 gp_10304 FAILED first error at gp_10000.c:6752
 gp_10305 FAILED first error at gp_10000.c:6772
 gp_10632 FAILED first error at gp_10000.c:15608
 gp_10633 FAILED first error at gp_10000.c:15629
 gp_10634 FAILED first error at gp_10000.c:15650
 gp_10706 FAILED first error at gp_10000.c:17375
 gp_10707 FAILED first error at gp_10000.c:17396
 gp_10708 FAILED first error at gp_10000.c:17417
 gp_10780 FAILED first error at gp_10000.c:19142
 gp_10781 FAILED first error at gp_10000.c:19163
 gp_10782 FAILED first error at gp_10000.c:19184
 gp_10854 FAILED first error at gp_10000.c:20909
 gp_10855 FAILED first error at gp_10000.c:20930
 gp_10856 FAILED first error at gp_10000.c:20951

For each failed test there is a TA log:

 E/TA:  checkUpdateParameterMemref:195 Received buffer is not NULL but expected to be NULL.

Link: [1] https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=d4fb5f166c2b
Link: [2] https://github.com/OP-TEE/optee_os/issues/4897
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
