### PR TITLE
qemu-check.exp: match core assert/panic strings on a single line

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -75,11 +75,11 @@ proc check_test_result arg {
 		# Exit when result separator is seen
 		"+-----------------------------------------------------\r\r" {}
 		# Handle errors in TEE core output
-		-i $arg -re {(^..TC:.*assertion.*failed at.*)\n} {
+		-i $arg -re {(..TC:[^\n]*assertion[^\n]*failed at[^\n]*)} {
 			info "!!! $expect_out(1,string)\n"
 			exit 1
 		}
-		-i $arg -re {(^..TC:.*Panic at.*)\n} {
+		-i $arg -re {(..TC:[^\n]*Panic at[^\n]*)} {
 			info "!!! $expect_out(1,string)\n"
 			exit 1
 		}


### PR DESCRIPTION
The regular expression used to detect TEE core panics or assertion
failures must not allow multi-line text to match, otherwise the following
input may trigger it:

E/TC:? 0 TA panicked with code 0xbeef
E/LD:  Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
E/LD:   arch: arm
E/LD:  region  0: va 0x00102000 pa 0x0e300000 size 0x002000 flags rw-s (ldelf)
E/LD:  region  1: va 0x00104000 pa 0x0e302000 size 0x00e000 flags r-xs (ldelf)
E/LD:  region  2: va 0x00112000 pa 0x0e310000 size 0x001000 flags rw-s (ldelf)
E/LD:  region  3: va 0x00113000 pa 0x0e311000 size 0x004000 flags rw-s (ldelf)
E/LD:  region  4: va 0x00117000 pa 0x0e315000 size 0x001000 flags r--s
E/LD:  region  5: va 0x00118000 pa 0x0e410000 size 0x003000 flags rw-s (stack)
E/LD:  region  6: va 0x00184000 pa 0x00001000 size 0x015000 flags r-xs [0]
E/LD:  region  7: va 0x00199000 pa 0x00016000 size 0x0e5000 flags rw-s [0]
E/LD:  assertion 'maps[map_idx].sz == sz' failed at ldelf/ta_elf.c:1451 in ta_elf_print_mappings()

Test case: xtest 1007 with "make COMPILER=clang".

Fixes: 09900ef99b70 ("qemu-check.exp: trap only OP-TEE Core assert or panic")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
