### PR TITLE
stm32mp1: rely on stm32mp15_defconfig

### DIFF
--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -120,14 +120,8 @@ tfa-clean:
 ################################################################################
 U_BOOT_EXPORTS ?= CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
 
-# Use stm32mp15_optee_defconfig up to U-Boot v2020.07-rc2.
-# Use stm32mp15_trusted_defconfig from v2020.07-rc3 onward.
 u-boot:
-ifneq ($(wildcard $(U_BOOT_PATH)/configs/stm32mp15_optee_defconfig),)
-	$(U_BOOT_EXPORTS) $(MAKE) -C $(U_BOOT_PATH) stm32mp15_optee_defconfig
-else
-	$(U_BOOT_EXPORTS) $(MAKE) -C $(U_BOOT_PATH) stm32mp15_trusted_defconfig
-endif
+	$(U_BOOT_EXPORTS) $(MAKE) -C $(U_BOOT_PATH) stm32mp15_defconfig
 	$(U_BOOT_EXPORTS) $(MAKE) -C $(U_BOOT_PATH) DEVICE_TREE=$(STM32MP1_DTS_BASENAME) all
 	@$(call install_in_binaries,$(U_BOOT_PATH)/$(U_BOOT_BIN))
 	@$(call install_in_binaries,$(U_BOOT_PATH)/$(U_BOOT_DTB))


### PR DESCRIPTION
Configures U-Boot with stm32mp15_defconfig that was introduced in
U-Boot tag v2021.10 for devices booted with OP-TEE and U-Boot stored
in TF-A FIP container. From U-Boot v2021.10 onward,
stm32mp15_trusted_defconfig is dedicated to boot scheme that do not
use TF-A FIP format.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
