### PR TITLE
common: add -t to set initial title for gnome-terminal

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -489,7 +489,7 @@ xterm := $(shell command -v xterm 2>/dev/null)
 ifdef gnome-terminal
 define launch-terminal
 	@nc -z  127.0.0.1 $(1) || \
-	$(gnome-terminal) -x $(BUILD_PATH)/soc_term.py $(1) &
+	$(gnome-terminal) -t $(2) -x $(BUILD_PATH)/soc_term.py $(1) &
 endef
 else
 ifdef xterm


### PR DESCRIPTION
The warning on option "-t" is remove in below commit.

https://gitlab.gnome.org/GNOME/gnome-terminal/-/commit/54da2fe919634e2d6a6aab392b36449947b812cd

And it seens work again, so add it back to make the
terminal title understandable.

Below is my test environment:
- Ubuntu 21.10
- GNOME Terminal 3.38.1 using VTE 0.64.2 +BIDI +GNUTLS +ICU +SYSTEMD




<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
