### PR TITLE
qemu_v8: xen: increase guest RAM from 128 to 160 MB

### DIFF
--- a/qemu_v8/xen/guest.cfg
+++ b/qemu_v8/xen/guest.cfg
@@ -1,5 +1,5 @@
 kernel="/mnt/host/linux/arch/arm64/boot/Image"
-memory=128
+memory=160
 vcpus=1
 command="console=hvc0 earlycon=xenboot"
 ramdisk = "/mnt/host/out-br-domu/images/rootfs.cpio.gz"


### PR DESCRIPTION
Increase the size of the guest (DomU) RAM from 128 to 160 MB to fix
an issue with xtest 6018:

  * regression_6018 Large object
  o regression_6018.1 Storage id: 00000001
  writing 0
  writing 1
  writing 2
  writing 3
  writing 4
  writing 5
  regression_6000.c:1895: fs_write(&sess, obj, block, block_size) has an unexpected value: 0xffff3024 = TEE_ERROR_TARGET_DEAD, expected 0x0 = TEEC_SUCCESS
    regression_6018.1 FAILED

For some reason, this test passes in CI [1] but not on my laptop
("make XEN_BOOT=y run", login: "root", run /bin/domu, login: "test"
then run "xtest 6018"). tee-supplicant receives error ENOSPC when
trying to write to /data/tee. Since the root FS in the guest is a
ramdisk, increasing the RAM seems to be the appropriate solution.

Link: [1] https://github.com/OP-TEE/optee_os/blob/578f89d28d2b66c35128f095989c355fbc2ef3ab/.azure-pipelines.yml#L256
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
