### PR TITLE
toolchain.mk: allow parallel build of cross-compiler on Aarch64 hosts

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -36,8 +36,8 @@ define build_toolchain
 		--br-defconfig build/br-ext/configs/sdk-$1 \
 		--br-defconfig build/br-ext/configs/sdk-common \
 		--make-cmd $(MAKE))
-	@$(MAKE) -C ../out-$1-sdk clean
-	@$(MAKE) -C ../out-$1-sdk sdk
+	+@$(MAKE) -C ../out-$1-sdk clean
+	+@$(MAKE) -C ../out-$1-sdk sdk
 	@tar xf ../out-$1-sdk/images/$3-buildroot-linux-$4_sdk-buildroot.tar.gz \
 		-C $2 --strip-components=1
 	@touch $2/.done


### PR DESCRIPTION
On an Aarch64 host, "make toolchain" does not use parallel jobs when
building the Aarch64 GCC and the following warning is shown:

 $ make -j32 toolchains
 [...]
 make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.

Therefore, add the '+' sign as recommended. This speeds up the build
quite a bit on a 32-core machine for example.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
