### PR TITLE
common.mk: buildroot: force make -j1 in buildroot when not per-package

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -332,6 +332,10 @@ append-var_ = echo '$(1)=$(3)'$($(1))'$(3)' >>$(2);
 append-var = $(call append-var_,$(1),$(2),$(if $(call y-or-n,$($(1))),,$(double-quote)))
 append-br2-vars = $(foreach var,$(filter BR2_%,$(.VARIABLES)),$(call append-var,$(var),$(1)))
 
+ifneq (y,$(BR2_PER_PACKAGE_DIRECTORIES))
+br-make-flags := -j1
+endif
+
 .PHONY: buildroot
 buildroot: optee-os optee-rust
 	@mkdir -p ../out-br
@@ -351,7 +355,7 @@ buildroot: optee-os optee-rust
 		$(DEFCONFIG_FTPM) \
 		--br-defconfig out-br/extra.conf \
 		--make-cmd $(MAKE))
-	@$(MAKE) -C ../out-br all
+	@$(MAKE) $(br-make-flags) -C ../out-br all
 
 .PHONY: buildroot-clean
 buildroot-clean:
@@ -376,7 +380,7 @@ buildroot-domu: optee-os
 		$(DEFCONFIG_GDBSERVER) \
 		--br-defconfig out-br-domu/extra.conf \
 		--make-cmd $(MAKE))
-	@$(MAKE) -C ../out-br-domu all
+	@$(MAKE) $(br-make-flags) -C ../out-br-domu all
 
 .PHONY: buildroot-domu-clean
 buildroot-domu-clean:


### PR DESCRIPTION
```
Buildroot parallel build is allowed when BR2_PER_PACKAGE_DIRECTORIES is
'y', see commit e9bff1c86e93 ("common.mk: buildroot: enable top-level
parallel build"). When disabled, Buildroot is not supposed to spawn
several make jobs simultaneously. However for some reason it seems it
can happen, see the IBART failure at [1]. The steps:
 >>> optee_client_ext 1.0 Fixing libtool files
and:
 >>> pcsc-lite 1.9.4 Fixing libtool files
...seem to be running simultaneously and touching the same path (since
per-package is disabled), which results in:
 mv: cannot stat '/home/optee/devel/qemu/out-br/host/arm-buildroot-linux-gnueabihf/sysroot/usr/lib/libpcsclite.la.fixed': No such file or directory
 package/pkg-generic.mk:331: recipe for target '/home/optee/devel/qemu/out-br/build/pcsc-lite-1.9.4/.stamp_staging_installed' failed

I confirmed the fact by adding a 'sleep 5' after "Fixing libtool files"
in package/pkg-generic.mk, as well as a 'ps -ef | grep sleep | grep -v
grep || :' just before the sleep. Then when building with
'make -j32 BR2_PER_PACKAGE_DIRECTORIES=n' (32 core machine) the 'sleep 5'
is displayed occasionally.

To avoid that, let's explicitly invoke make with -j1 when
BR2_PER_PACKAGE_DIRECTORIES is disabled.

Link: [1] https://optee.mooo.com:5000/logs/OP-TEE/optee_os/5487/1027234243/9147c347fb53612f62bf7de1c17e47a246d61ef2#02-qemu-build line 16398:
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```