### PR TITLE
fvp: add support for Secure Partitions in the FIP

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -5,6 +5,7 @@ MEASURED_BOOT			?= y
 MEASURED_BOOT_FTPM		?= n
 TS_SMM_GATEWAY			?= y
 TS_UEFI_TESTS			?= y
+SP_PACKAGING_METHOD		?= embedded # Supported values: embedded, fip
 
 TF_A_FLAGS ?= \
 	BL32=$(OPTEE_OS_PAGER_V2_BIN) \
@@ -12,7 +13,8 @@ TF_A_FLAGS ?= \
 	PLAT=fvp \
 	SPD=spmd \
 	SPMD_SPM_AT_SEL2=0 \
-	ARM_SPMC_MANIFEST_DTS=$(ROOT)/build/fvp/spmc_manifest.dts
+	ARM_SPMC_MANIFEST_DTS=$(ROOT)/build/fvp/spmc_manifest.dts \
+	$(TF_A_FIP_SP_FLAGS)
 
 include fvp.mk
 include trusted-services.mk

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ */
+
+internal_trusted_storage {
+	uuid = "dc1eef48-b17a-4ccf-ac8b-dfcff7711b14";
+	load-address = <0x7a00000>;
+};
+
+protected_storage_sp {
+	uuid = "751bf801-3dde-4768-a514-0f10aeed1790";
+	load-address = <0x7b00000>;
+};
+
+crypto_sp {
+	uuid = "d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0";
+	load-address = <0x7c00000>;
+};
+
+#if MEASURED_BOOT
+initial_attestation_sp {
+	uuid = "a1baf155-8876-4695-8f7c-54955e8db974";
+	load-address = <0x7d00000>;
+};
+#endif
+
+smm_gateway {
+	uuid = "ed32d533-99e6-4209-9cc0-2d72cdd998a7";
+	load-address = <0x7e00000>;
+};

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -32,4 +32,37 @@
 		tpm_event_log_size = <0x0>;
 	};
 #endif
+
+/* If the ARM_BL2_SP_LIST_DTS is defined, SPs should be loaded from FIP */
+#ifdef ARM_BL2_SP_LIST_DTS
+	sp_packages {
+		compatible = "arm,sp_pkg";
+		internal_trusted_storage {
+			uuid = <0x48ef1edc 0xcf4c7ab1 0xcfdf8bac 0x141b71f7>;
+			load-address = <0x0 0x7a00000>;
+		};
+
+		protected_storage_sp {
+			uuid = <0x01f81b75 0x6847de3d 0x100f14a5 0x9017edae>;
+			load-address = <0x0 0x7b00000>;
+		};
+
+		crypto_sp {
+			uuid = <0xd552dfd9 0xb24ba216 0x6dd2a49a 0xc0e8843b>;
+			load-address = <0x0 0x7c00000>;
+		};
+
+#if MEASURED_BOOT
+		initial_attestation_sp {
+			uuid = <0x55f1baa1 0x95467688 0x95547c8f 0x74b98d5e>;
+			load-address = <0x0 0x7d00000>;
+		};
+#endif
+
+		smm_gateway {
+			uuid = <0x33d532ed 0x0942e699 0x722dc09c 0xa798d9cd>;
+			load-address = <0x0 0x7e00000>;
+		};
+	};
+#endif
 };

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -59,8 +59,17 @@ ffa-sp-all-realclean: ffa-$1-sp-realclean
 optee_os_sp_paths += $(TS_INSTALL_PREFIX)/opteesp/bin/$2.stripped.elf
 endef
 
+ifeq ($(SP_PACKAGING_METHOD),embedded)
 # Add the list of SP paths to the optee_os config
 OPTEE_OS_COMMON_EXTRA_FLAGS += SP_PATHS="$(optee_os_sp_paths)"
+else ifeq ($(SP_PACKAGING_METHOD),fip)
+# Configure TF-A to load the SPs from FIP by BL2
+TF_A_FIP_SP_FLAGS += ARM_BL2_SP_LIST_DTS=$(ROOT)/build/fvp/bl2_sp_list.dtsi \
+		SP_LAYOUT_FILE=$(TS_INSTALL_PREFIX)/opteesp/json/sp_layout.json
+
+# This should be removed when TF-A is updated to v2.7 or later
+$(call force,MEASURED_BOOT,n,Need TF-A v2.7 for FIP SPs with Measured Boot)
+endif
 
 ################################################################################
 # Linux FF-A user space drivers


### PR DESCRIPTION
This commit introduces a new packaging option for Secure Partitions. Instead of embedding the images into the OP-TEE binary, TF-A offers a mechanism to encapsulate an SP image and its manifest into an SP package and add that to the FIP.
https://trustedfirmware-a.readthedocs.io/en/v2.6/components/secure-partition-manager.html#secure-partition-packages

TF-A needs two config options to enable this:

- SP_LAYOUT_FILE: This json file contains the path of the SP images and their corresponding manifests. It's generated by Trusted Services.
- ARM_BL2_SP_LIST_DTS: This dts snippet describes where each SP package should be loaded by BL2.

Depends on:

- https://github.com/OP-TEE/optee_os/pull/5519
- https://review.trustedfirmware.org/q/topic:fip-sp