### PR TITLE
rust: fix make optee-rust

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -542,7 +542,9 @@ optee-rust: $(OPTEE_RUST_PATH)/.done
 
 $(OPTEE_RUST_PATH)/.done:
 ifeq ($(OPTEE_RUST_ENABLE),y)
-	@(export OPTEE_DIR=$(ROOT) && cd $(OPTEE_RUST_PATH) && ./setup.sh && touch .done)
+	@(export OPTEE_DIR=$(ROOT) && \
+	  export CARGO_NET_GIT_FETCH_WITH_CLI=true && \
+	  cd $(OPTEE_RUST_PATH) && ./setup.sh && touch .done)
 endif
 
 optee-rust-clean:


### PR DESCRIPTION
In some environments it has been noted that the Rust setup fails with a netowrk error [1]. It seems to be an issue with the built-in Git library, a workaround being to tell the Rust setup to use the Git command instead. This commit does exactly that, regardless of the environment.

Note: I chose not to restore the OP-TEE Rust build commands removed by [1] in order to reduce the size of the image ($TOP/optee_rust is 1.8GB after building) and avoid disk space issues in the "make check (QEMUv8)" job which uses this image but doesn't build the Rust tests. The "make check-rust (QEMUv8)" job will do whataver it takes.

Link: [1] https://github.com/jforissier/docker_optee_os_ci/commit/6d7f39aec9436168e5e4ce44c4b6f7791575e313
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
