### PR TITLE
fvp: remove extra whitespace

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -5,7 +5,8 @@ MEASURED_BOOT			?= y
 MEASURED_BOOT_FTPM		?= n
 TS_SMM_GATEWAY			?= y
 TS_UEFI_TESTS			?= y
-SP_PACKAGING_METHOD		?= embedded # Supported values: embedded, fip
+# Supported values: embedded, fip
+SP_PACKAGING_METHOD		?= embedded
 
 TF_A_FLAGS ?= \
 	BL32=$(OPTEE_OS_PAGER_V2_BIN) \


### PR DESCRIPTION
Move a comment line which accidentally added a whitespace to the end of SP_PACKAGING_METHOD default value.

Fixes: db9b8f09aeeb ("fvp: add support for Secure Partitions in the FIP")