### PR TITLE
Zynqmp new platforms

### DIFF
--- a/zynqmp.mk
+++ b/zynqmp.mk
@@ -8,8 +8,19 @@ override COMPILE_NS_KERNEL := 64
 override COMPILE_S_USER    := 64
 override COMPILE_S_KERNEL  := 64
 
-PLATFORM = zynqmp-zcu102
+PLATFORM := zynqmp-zcu102
+
+ifeq ($(PLATFORM),zynqmp-ultra96)
+OPTEE_OS_PLATFORM = zynqmp-ultra96
+else
 OPTEE_OS_PLATFORM = zynqmp-zcu102
+endif
+
+DTS_zynqmp-zcu102 = zynqmp-zcu102-rev1.0
+DTS_zynqmp-zcu104 = zynqmp-zcu104-revC
+DTS_zynqmp-zcu106 = zynqmp-zcu106-revA
+DTS_zynqmp-ultra96 = avnet-ultra96-rev1
+U-BOOT_DTS = $(DTS_$(PLATFORM))
 
 ################################################################################
 # Paths to git projects and various binaries
@@ -60,7 +71,6 @@ optee-os-clean: optee-os-clean-common
 
 U-BOOT_EXPORTS = CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)"
 U-BOOT_CONFIG = xilinx_zynqmp_virt_defconfig
-U-BOOT_DTS = zynqmp-zcu102-rev1.0
 
 u-boot:
 	$(U-BOOT_EXPORTS) $(MAKE) -C $(U-BOOT_PATH) $(U-BOOT_CONFIG)
@@ -165,7 +175,7 @@ else
 endif
 
 firmware-clean:
-	rm -rf ../zcu102-release
+	rm -rf ../$(PLATFORM)-release
 
 ###############################################################################
 # FIT Image

--- a/zynqmp/bootImage-zynqmp-ultra96.bif
+++ b/zynqmp/bootImage-zynqmp-ultra96.bif
@@ -1,0 +1,8 @@
+all:
+{
+	[pmufw_image] ../zynqmp-ultra96-release/pmufw.elf
+	[bootloader, destination_cpu = a53-0] ../zynqmp-ultra96-release/zynqmp_fsbl.elf
+	[destination_cpu = a53-0, exception_level = el-3, trustzone] ../arm-trusted-firmware/build/zynqmp/release/bl31/bl31.elf
+	[destination_cpu = a53-0, exception_level = el-2] ../u-boot-xlnx/u-boot.elf
+	[destination_cpu = a53-0, load=0x60000000, startup=0x60000000, exception_level = el-1, trustzone] ../optee_os/out/arm/core/tee_raw.bin
+}

--- a/zynqmp/bootImage-zynqmp-zcu104.bif
+++ b/zynqmp/bootImage-zynqmp-zcu104.bif
@@ -1,0 +1,8 @@
+all:
+{
+	[pmufw_image] ../zynqmp-zcu104-release/pmufw.elf
+	[bootloader, destination_cpu = a53-0] ../zynqmp-zcu104-release/zynqmp_fsbl.elf
+	[destination_cpu = a53-0, exception_level = el-3, trustzone] ../arm-trusted-firmware/build/zynqmp/release/bl31/bl31.elf
+	[destination_cpu = a53-0, exception_level = el-2] ../u-boot-xlnx/u-boot.elf
+	[destination_cpu = a53-0, load=0x60000000, startup=0x60000000, exception_level = el-1, trustzone] ../optee_os/out/arm/core/tee_raw.bin
+}

--- a/zynqmp/bootImage-zynqmp-zcu106.bif
+++ b/zynqmp/bootImage-zynqmp-zcu106.bif
@@ -1,0 +1,8 @@
+all:
+{
+	[pmufw_image] ../zynqmp-zcu106-release/pmufw.elf
+	[bootloader, destination_cpu = a53-0] ../zynqmp-zcu106-release/zynqmp_fsbl.elf
+	[destination_cpu = a53-0, exception_level = el-3, trustzone] ../arm-trusted-firmware/build/zynqmp/release/bl31/bl31.elf
+	[destination_cpu = a53-0, exception_level = el-2] ../u-boot-xlnx/u-boot.elf
+	[destination_cpu = a53-0, load=0x60000000, startup=0x60000000, exception_level = el-1, trustzone] ../optee_os/out/arm/core/tee_raw.bin
+}

--- a/zynqmp/fitImage-zynqmp-ultra96.its
+++ b/zynqmp/fitImage-zynqmp-ultra96.its
@@ -1,0 +1,67 @@
+/dts-v1/;
+
+/ {
+    description = "U-Boot fitImage for plnx_aarch64 kernel";
+    #address-cells = <1>;
+
+    images {
+        kernel {
+            description = "Linux Kernel";
+            data = /incbin/("./../../linux-xlnx/arch/arm64/boot/Image");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x80000>;
+            entry = <0x80000>;
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-1 {
+            description = "Flattened Device Tree blob";
+            data = /incbin/("../../u-boot-xlnx/arch/arm/dts/avnet-ultra96-rev1.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x10000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-2 {
+            description = "Flattened Device Tree overlay";
+            data = /incbin/("zynqmp-optee.dtbo");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x11000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        ramdisk {
+            description = "ramdisk";
+            data = /incbin/("../../out-br/images/rootfs.cpio.gz");
+            type = "ramdisk";
+            arch = "arm64";
+            os = "linux";
+            compression = "gzip";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+    configurations {
+        default = "conf";
+        conf {
+            description = "Boot Linux kernel with FDT blob + ramdisk";
+            kernel = "kernel";
+            fdt = "fdt-1", "fdt-2";
+	    ramdisk = "ramdisk";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+};

--- a/zynqmp/fitImage-zynqmp-zcu102.its
+++ b/zynqmp/fitImage-zynqmp-zcu102.its
@@ -14,7 +14,7 @@
             compression = "none";
             load = <0x80000>;
             entry = <0x80000>;
-            hash@1 {
+            hash {
                 algo = "sha1";
             };
         };
@@ -25,7 +25,7 @@
             arch = "arm64";
             load = <0x10000000>;
             compression = "none";
-            hash@1 {
+            hash {
                 algo = "sha1";
             };
         };
@@ -36,7 +36,7 @@
             arch = "arm64";
             load = <0x11000000>;
             compression = "none";
-            hash@1 {
+            hash {
                 algo = "sha1";
             };
         };
@@ -47,19 +47,19 @@
             arch = "arm64";
             os = "linux";
             compression = "gzip";
-            hash@1 {
+            hash {
                 algo = "sha1";
             };
         };
     };
     configurations {
-        default = "conf@1";
-        conf@1 {
+        default = "conf";
+        conf {
             description = "Boot Linux kernel with FDT blob + ramdisk";
             kernel = "kernel";
             fdt = "fdt-1", "fdt-2";
 	    ramdisk = "ramdisk";
-            hash@1 {
+            hash {
                 algo = "sha1";
             };
         };

--- a/zynqmp/fitImage-zynqmp-zcu104.its
+++ b/zynqmp/fitImage-zynqmp-zcu104.its
@@ -1,0 +1,67 @@
+/dts-v1/;
+
+/ {
+    description = "U-Boot fitImage for plnx_aarch64 kernel";
+    #address-cells = <1>;
+
+    images {
+        kernel {
+            description = "Linux Kernel";
+            data = /incbin/("./../../linux-xlnx/arch/arm64/boot/Image");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x80000>;
+            entry = <0x80000>;
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-1 {
+            description = "Flattened Device Tree blob";
+            data = /incbin/("../../u-boot-xlnx/arch/arm/dts/zynqmp-zcu104-revC.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x10000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-2 {
+            description = "Flattened Device Tree overlay";
+            data = /incbin/("zynqmp-optee.dtbo");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x11000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        ramdisk {
+            description = "ramdisk";
+            data = /incbin/("../../out-br/images/rootfs.cpio.gz");
+            type = "ramdisk";
+            arch = "arm64";
+            os = "linux";
+            compression = "gzip";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+    configurations {
+        default = "conf";
+        conf {
+            description = "Boot Linux kernel with FDT blob + ramdisk";
+            kernel = "kernel";
+            fdt = "fdt-1", "fdt-2";
+	    ramdisk = "ramdisk";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+};

--- a/zynqmp/fitImage-zynqmp-zcu106.its
+++ b/zynqmp/fitImage-zynqmp-zcu106.its
@@ -1,0 +1,67 @@
+/dts-v1/;
+
+/ {
+    description = "U-Boot fitImage for plnx_aarch64 kernel";
+    #address-cells = <1>;
+
+    images {
+        kernel {
+            description = "Linux Kernel";
+            data = /incbin/("./../../linux-xlnx/arch/arm64/boot/Image");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x80000>;
+            entry = <0x80000>;
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-1 {
+            description = "Flattened Device Tree blob";
+            data = /incbin/("../../u-boot-xlnx/arch/arm/dts/zynqmp-zcu106-revA.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x10000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdt-2 {
+            description = "Flattened Device Tree overlay";
+            data = /incbin/("zynqmp-optee.dtbo");
+            type = "flat_dt";
+            arch = "arm64";
+            load = <0x11000000>;
+            compression = "none";
+            hash {
+                algo = "sha1";
+            };
+        };
+        ramdisk {
+            description = "ramdisk";
+            data = /incbin/("../../out-br/images/rootfs.cpio.gz");
+            type = "ramdisk";
+            arch = "arm64";
+            os = "linux";
+            compression = "gzip";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+    configurations {
+        default = "conf";
+        conf {
+            description = "Boot Linux kernel with FDT blob + ramdisk";
+            kernel = "kernel";
+            fdt = "fdt-1", "fdt-2";
+	    ramdisk = "ramdisk";
+            hash {
+                algo = "sha1";
+            };
+        };
+    };
+};

--- a/zynqmp/zynqmp-optee.dtso
+++ b/zynqmp/zynqmp-optee.dtso
@@ -10,4 +10,25 @@
 			};
 		};
 	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			reserved-memory {
+				#address-cells = <2>;
+		                #size-cells = <2>;
+				ranges;
+
+				atf@0 {
+					reg = <0x0 0x1000 0x0 0x1f000>;
+					no-map;
+				};
+
+				optee@60000000 {
+					reg = <0x0 0x60000000 0x0 0x10000000>;
+					no-map;
+				};
+			};
+		};
+	};
 };


### PR DESCRIPTION
Add support in the build repository for the previously supported evaluation boards. The pull request includes a patch to the DTS overlay to ensure that kernel does not overwrite either ATF or OP-Tee specially in the ZCU104 and Ultra96 boards where DDR memory is more limited.
