### PR TITLE
qemu_v8: PAUTH for OP-TEE Core

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -331,6 +331,7 @@ endif
 
 ifeq ($(PAUTH),y)
 OPTEE_OS_COMMON_FLAGS += CFG_TA_PAUTH=y
+OPTEE_OS_COMMON_FLAGS += CFG_CORE_PAUTH=y
 endif
 ifeq ($(MEMTAG),y)
 OPTEE_OS_COMMON_FLAGS += CFG_MEMTAG=y
@@ -406,7 +407,7 @@ QEMU_VIRT	= true
 QEMU_XEN	?= -drive if=none,file=$(XEN_EXT4),format=raw,id=hd1 \
 		   -device virtio-blk-device,drive=hd1
 else
-QEMU_CPU	?= max,sve=off
+QEMU_CPU	?= max,sve=off,pauth-impdef=on
 QEMU_SMP 	?= 2
 QEMU_MEM 	?= 1057
 QEMU_VIRT	= false


### PR DESCRIPTION
Adds CFG_CORE_PAUTH=y when configured with PAUTH=y. Also adds pauth-impdef=on to QEMU_CPU to avoid performance degradation when testing with CFG_CORE_PAUTH=y.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
