### PR TITLE
versal: remove the @ from fitImage-versal-vck190.its

### DIFF
--- a/versal/fitImage-versal-vck190.its
+++ b/versal/fitImage-versal-vck190.its
@@ -14,7 +14,7 @@
             compression = "none";
             load = <0x80000>;
             entry = <0x80000>;
-            hash@1 {
+            hash1 {
                 algo = "sha1";
             };
         };
@@ -25,7 +25,7 @@
             arch = "arm64";
             load = <0x10000000>;
             compression = "none";
-            hash@1 {
+            hash1 {
                 algo = "sha1";
             };
         };
@@ -36,7 +36,7 @@
             arch = "arm64";
             load = <0x11000000>;
             compression = "none";
-            hash@1 {
+            hash1 {
                 algo = "sha1";
             };
         };
@@ -47,19 +47,19 @@
             arch = "arm64";
             os = "linux";
             compression = "gzip";
-            hash@1 {
+            hash1 {
                 algo = "sha1";
             };
         };
     };
     configurations {
-        default = "conf@1";
-        conf@1 {
+        default = "conf1";
+        conf1 {
             description = "Boot Linux kernel with FDT blob + ramdisk";
             kernel = "kernel";
             fdt = "fdt-1", "fdt-2";
 	    ramdisk = "ramdisk";
-            hash@1 {
+            hash1 {
                 algo = "sha1";
             };
         };


### PR DESCRIPTION
Signed-off-by: Nathan Menhorn <nathan.menhorn@amd.com>

When executing the command `$ make -f versal.mk image` when following the instructions in:

https://github.com/OP-TEE/optee_docs/blob/master/building/devices/versal.rst#configuring-and-building-for-vck190 

an error is being encountered when trying to recreate this build using Ubuntu 20.04.5 LTS

`../u-boot/tools/mkimage -f versal/fitImage-versal-vck190.its versal/versal-vck190.ub`
`versal/fitImage-versal-vck190.its:17.20-19.15: Warning (unit_address_vs_reg): /images/kernel/hash@1: node has a unit name, but no reg property`
`versal/fitImage-versal-vck190.its:28.20-30.15: Warning (unit_address_vs_reg): /images/fdt-1/hash@1: node has a unit name, but no reg property`
`versal/fitImage-versal-vck190.its:39.20-41.15: Warning (unit_address_vs_reg): /images/fdt-2/hash@1: node has a unit name, but no reg property`
`versal/fitImage-versal-vck190.its:50.20-52.15: Warning (unit_address_vs_reg): /images/ramdisk/hash@1: node has a unit name, but no reg property`
`versal/fitImage-versal-vck190.its:57.16-65.11: Warning (unit_address_vs_reg): /configurations/conf@1: node has a unit name, but no reg property`
`versal/fitImage-versal-vck190.its:62.20-64.15: Warning (unit_address_vs_reg): /configurations/conf@1/hash@1: node has a unit name, but no reg property`
`../u-boot/tools/mkimage: verify_header failed for FIT Image support with exit code 1`
`make: *** [versal.mk:157: fitimage] Error 1`

This pull request fixes #592 

CC: @ldts 