### PR TITLE
buildroot: add docopt.cpp_ext package

### DIFF
--- a/br-ext/Config.in
+++ b/br-ext/Config.in
@@ -1,3 +1,4 @@
+source "$BR2_EXTERNAL_OPTEE_PATH/package/docopt.cpp_ext/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_os_ext/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_client_ext/Config.in"
 source "$BR2_EXTERNAL_OPTEE_PATH/package/optee_test_ext/Config.in"

--- a/br-ext/package/docopt.cpp_ext/Config.in
+++ b/br-ext/package/docopt.cpp_ext/Config.in
@@ -1,0 +1,15 @@
+config BR2_PACKAGE_DOCOPT_CPP_EXT
+	bool "docopt.cpp_ext"
+	depends on BR2_INSTALL_LIBSTDCPP
+	depends on BR2_TOOLCHAIN_GCC_AT_LEAST_4_7 # C++11
+	help
+	  docopt is a library that lets you define a command line
+	  interface with the utility argument syntax that has been
+	  used by command line utilities for decades (POSIX.1-2017).
+	  From the description, docopt automatically generates a parser
+	  for the command line arguments.
+
+	  docopt Command-line interface description language
+	  http://docopt.org/
+
+	  docopt C++ port https://github.com/docopt/docopt.cpp

--- a/br-ext/package/docopt.cpp_ext/docopt.cpp_ext.hash
+++ b/br-ext/package/docopt.cpp_ext/docopt.cpp_ext.hash
@@ -1,0 +1,6 @@
+# Locally computed:
+sha256  28af5a0c482c6d508d22b14d588a3b0bd9ff97135f99c2814a5aa3cbff1d6632  v0.6.3.tar.gz
+
+# Hash for license files:
+sha256  c9bff75738922193e67fa726fa225535870d2aa1059f91452c411736284ad566  LICENSE-Boost-1.0
+sha256  b2959a980bc25f5d5e020d7a31777b7184aace6eb160acc80619f85edf646f19  LICENSE-MIT

--- a/br-ext/package/docopt.cpp_ext/docopt.cpp_ext.mk
+++ b/br-ext/package/docopt.cpp_ext/docopt.cpp_ext.mk
@@ -1,0 +1,13 @@
+################################################################################
+#
+# docopt.cpp_ext
+#
+################################################################################
+
+DOCOPT_CPP_EXT_VERSION = 0.6.3
+DOCOPT_CPP_EXT_SOURCE = v$(DOCOPT_CPP_EXT_VERSION).tar.gz
+DOCOPT_CPP_EXT_SITE = https://github.com/docopt/docopt.cpp/archive/refs/tags
+DOCOPT_CPP_EXT_INSTALL_STAGING = YES
+DOCOPT_CPP_EXT_LICENSE_FILES = LICENSE-Boost-1.0 LICENSE-MIT
+
+$(eval $(cmake-package))


### PR DESCRIPTION
Add docopt.cpp library that can be used to create intuitive command line interfaces with very little code by describing the valid calls using the (POSIX.1-2017) command line utility argument syntax.

This is in preparation for adding the Command Line tool from https://github.com/OP-TEE/optee_client/pull/259 (not merged). The intent is that the CLI tool and and this library will be optional components in the build.

 I'm opening this as a PR first here, and plan to post it a bit later also to buildroot mailing list as the `docopt.cpp` package.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
