### PR TITLE
soc_term.py: write to stdout not stdin

### DIFF
--- a/soc_term.py
+++ b/soc_term.py
@@ -99,7 +99,7 @@ def serve_conn(conn):
                 buf = bytearray(data)
                 handle_telnet_codes(readyfd, buf)
                 if (readyfd == fd):
-                    to = sys.stdin.fileno()
+                    to = sys.stdout.fileno()
                 else:
                     to = fd
             except ConnectionResetError:


### PR DESCRIPTION
The serv_conn() function should write the data read from the connection to stdout, not stdin. Although stdin appears to work when soc_term is invoked from a terminal in an interactive session, things get bad when trying to redirect its output:

 $ ./soc_term 54320 | tee nsec.log
 <... make run etc. ...>
 ^C
 $ file nsec.log
 nsec.log: empty

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
