### PR TITLE
trusted-keys.exp: fix error detection

### DIFF
--- a/trusted-keys.exp
+++ b/trusted-keys.exp
@@ -4,25 +4,18 @@
 # source. The return code is 0 for success, >0 for error.
 #
 
-set timeout 60
+set timeout 5
 set tk_id 0
 set ek_id 0
+# Wait for next prompt, dealing with key ID, failure message and timeout
 proc check_keyctl_result arg {
 	expect {
-		-re "(\n)(\\d+)\r" {
-			set ::$arg $expect_out(2,string)
+		-re {(\d+)\r} {
+			set ::$arg $expect_out(1,string)
 			exp_continue
 		}
-		-re "Operation not permitted" {
-			info "keyctl failed: Operation not permitted\n"
-			exit 1
-		}
-		-re "No such device" {
-			info "keyctl failed: Trusted Keys support missing\n"
-			exit 1
-		}
-		-re "\n---" {
-			info "keyctl failed: mismatch\n"
+		"FAILED" {
+			info "!!! Error\n"
 			exit 1
 		}
 		timeout {
@@ -32,29 +25,35 @@ proc check_keyctl_result arg {
 		"# "
 	}
 }
+proc run_cmd arg {
+	send -- [append arg " || fail\r"]
+}
 info "Running: keyctl tests...\n"
-send -- "keyctl add trusted kmk \"new 32\" @u\r"
+expect "# "
+send -- "function fail { echo FAILED ; }\r"
+expect "# "
+run_cmd "keyctl add trusted kmk \"new 32\" @u"
 check_keyctl_result tk_id
-send -- "keyctl add encrypted evm \"new trusted:kmk 32\" @u\r"
+run_cmd "keyctl add encrypted evm \"new trusted:kmk 32\" @u"
 check_keyctl_result ek_id
-send -- "keyctl pipe $tk_id > kmk.blob\r"
+run_cmd "keyctl pipe $tk_id > kmk.blob"
 check_keyctl_result tk_id
-send -- "keyctl pipe $ek_id > evm.blob\r"
+run_cmd "keyctl pipe $ek_id > evm.blob"
 check_keyctl_result ek_id
-send -- "keyctl revoke $ek_id\r"
+run_cmd "keyctl revoke $ek_id"
 check_keyctl_result ek_id
-send -- "keyctl revoke $tk_id\r"
+run_cmd "keyctl revoke $tk_id"
 check_keyctl_result tk_id
-send -- "keyctl add trusted kmk \"load `cat kmk.blob`\" @u\r"
+run_cmd "keyctl add trusted kmk \"load `cat kmk.blob`\" @u"
 check_keyctl_result tk_id
-send -- "keyctl add encrypted evm \"load `cat evm.blob`\" @u\r"
+run_cmd "keyctl add encrypted evm \"load `cat evm.blob`\" @u"
 check_keyctl_result ek_id
-send -- "keyctl pipe $tk_id > kmk.blob2\r"
+run_cmd "keyctl pipe $tk_id > kmk.blob2"
 check_keyctl_result tk_id
-send -- "keyctl pipe $ek_id > evm.blob2\r"
+run_cmd "keyctl pipe $ek_id > evm.blob2"
 check_keyctl_result ek_id
-send -- "diff kmk.blob kmk.blob2\r"
+run_cmd "diff kmk.blob kmk.blob2"
 check_keyctl_result tk_id
-send -- "diff evm.blob evm.blob2\r"
+run_cmd "diff evm.blob evm.blob2"
 check_keyctl_result ek_id
 info "Status: keyctl tests successful\n"

--- a/trusted-keys.exp
+++ b/trusted-keys.exp
@@ -14,6 +14,12 @@ proc check_keyctl_result arg {
 			set ::$arg $expect_out(1,string)
 			exp_continue
 		}
+		"add_key: No such device" {
+			info [join {"Skipping test due to 'No such device':"
+				    "trusted keys are not supported"
+				    "(missing driver? CFG_CORE_DYN_SHM=n?)\n"}]
+			exit 0
+		}
 		"FAILED" {
 			info "!!! Error\n"
 			exit 1


### PR DESCRIPTION
The check_keyctl_result() procedure doesn't deal with all error cases properly. For example the following error is not reported:
```
 # keyctl add trusted kmk "new 32" @u
 [    7.293607] trusted-key-tee optee-ta-f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c: key shm register failed
 add_key: Invalid argument
 #
```
To make things simpler, rely on the exit status of the commands sent to the guest. The || shell construct is used to trigger the display of an error message ("FAILED"). To avoid having the message in the command themselves, which would make the parsing more complex, a shell function is introduced ("fail"). Then all the check_keyctl_result() procedure needs to do is wait for the next prompt ("# "), while dealing with errors (the "FAILED" word appearing anywhere), key ID (parsing is unchanged), and timeouts (which I have reduced to 5 seconds, more than enough for any operation in this test suite).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
