### PR TITLE
ffa: Allow multiple SPs with same UUID

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -7,7 +7,7 @@ TS_SMM_GATEWAY			?= y
 TS_UEFI_TESTS			?= y
 # Supported values: embedded, fip
 SP_PACKAGING_METHOD		?= embedded
-SPMC_TESTS			?= y
+SPMC_TESTS			?= n
 
 TF_A_FLAGS ?= \
 	BL32=$(OPTEE_OS_PAGER_V2_BIN) \

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -56,4 +56,5 @@ OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
 $(eval $(call build-sp,spm-test1,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test2,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test3,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test4,423762ed-7772-406f-99d8-0c27da0abbf8,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 endif

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -48,4 +48,8 @@ test_sp3 {
 	load-address = <0x7a20000>;
 };
 
+test_sp4 {
+	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
+	load-address = <0x7a30000>;
+};
 #endif

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -3,6 +3,7 @@
  * Copyright (c) 2022, Arm Limited. All rights reserved.
  */
 
+#ifndef CFG_SPMC_TESTS
 internal_trusted_storage {
 	uuid = "dc1eef48-b17a-4ccf-ac8b-dfcff7711b14";
 	load-address = <0x7a00000>;
@@ -29,3 +30,22 @@ smm_gateway {
 	uuid = "ed32d533-99e6-4209-9cc0-2d72cdd998a7";
 	load-address = <0x7e00000>;
 };
+
+#else
+
+test_sp1 {
+	uuid = "5c9edbc3-7b3a-4367-9f83-7c191ae86a37";
+	load-address = <0x7a00000>;
+};
+
+test_sp2 {
+	uuid = "7817164c-c40c-4d1a-867a-9bb2278cf41a";
+	load-address = <0x7a10000>;
+};
+
+test_sp3 {
+	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
+	load-address = <0x7a20000>;
+};
+
+#endif

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -81,6 +81,10 @@
 			load-address = <0x0 0x7a20000>;
 		};
 
+		test_sp4 {
+			uuid = <0xed623742 0x6f407277 0x270cd899 0xf8bb0ada>;
+			load-address = <0x0 0x7a30000>;
+		};
 #endif
 
 	};

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -37,6 +37,7 @@
 #ifdef ARM_BL2_SP_LIST_DTS
 	sp_packages {
 		compatible = "arm,sp_pkg";
+#ifndef CFG_SPMC_TESTS
 		internal_trusted_storage {
 			uuid = <0x48ef1edc 0xcf4c7ab1 0xcfdf8bac 0x141b71f7>;
 			load-address = <0x0 0x7a00000>;
@@ -63,6 +64,25 @@
 			uuid = <0x33d532ed 0x0942e699 0x722dc09c 0xa798d9cd>;
 			load-address = <0x0 0x7e00000>;
 		};
+
+#else /*CFG_SPMC_TESTS*/
+		test_sp1 {
+			uuid = <0xc3db9e5c 0x67433a7b 0x197c839f 0x376ae81a>;
+			load-address = <0x0 0x7a00000>;
+		};
+
+		test_sp2 {
+			uuid = <0x4c161778 0x1a4d0cc4 0xb29b7a86 0x1af48c27>;
+			load-address = <0x0 0x7a10000>;
+		};
+
+		test_sp3 {
+			uuid = <0x0001eb23 0x97442ae3 0x112f5290 0xa6af84e5>;
+			load-address = <0x0 0x7a20000>;
+		};
+
+#endif
+
 	};
 #endif
 };


### PR DESCRIPTION
Change the naming scheme of the SP binaries to make sure we can add multiple SPs with the same UUID to the system. 
This is need to support [PR](https://github.com/OP-TEE/optee_os/pull/5650)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
