### PR TITLE
zynqmp: use platform name as OPTEE platform

### DIFF
--- a/zynqmp.mk
+++ b/zynqmp.mk
@@ -9,12 +9,7 @@ override COMPILE_S_USER    := 64
 override COMPILE_S_KERNEL  := 64
 
 PLATFORM := zynqmp-zcu102
-
-ifeq ($(PLATFORM),zynqmp-ultra96)
-OPTEE_OS_PLATFORM = zynqmp-ultra96
-else
-OPTEE_OS_PLATFORM = zynqmp-zcu102
-endif
+OPTEE_OS_PLATFORM = $(PLATFORM)
 
 DTS_zynqmp-zcu102 = zynqmp-zcu102-rev1.0
 DTS_zynqmp-zcu104 = zynqmp-zcu104-revC


### PR DESCRIPTION
Recent patch in optee_os (c89e397c838f443db2b60ab20aac8565d21a8774) added ZCU104 and ZCU106 platform flavours, therefore there is no need anymore to use zcu102 platform to build optee_os for these boards.

Signed-off-by: Ibai Erkiaga <ibai.erkiaga-elorza@amd.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
