### PR TITLE
rockpi4: build and install kernel modules when LINUX_MODULES=y

### DIFF
--- a/kconfigs/u-boot_rockpi4.conf
+++ b/kconfigs/u-boot_rockpi4.conf
@@ -23,7 +23,7 @@ CONFIG_HUSH_PARSER=y
 CONFIG_CMD_FS_GENERIC=y
 CONFIG_CMD_EXT2=y
 CONFIG_USE_BOOTARGS=y
-CONFIG_BOOTARGS="console=ttyS2,1500000 root=PARTUUID=17d61bff-8fdc-4089-b675-9be21b9f6ac7 rootwait"
+CONFIG_BOOTARGS="console=ttyS2,1500000 root=PARTUUID=17d61bff-8fdc-4089-b675-9be21b9f6ac7 loglevel=6 rootwait"
 CONFIG_DEFAULT_FDT_FILE="/boot/rk3399-rock-pi-4b.dtb"
 CONFIG_USE_BOOTCOMMAND=y
 ## Note: kernel_addr_gz is arbitrarily chosen to be 100M (0xa0000000) above kernel_addr_r


### PR DESCRIPTION
Many things need kernel modules to work properly (for example, network access). Add support for this with "make LINUX_MODULES=y". It also takes care of configuring the ethernet port using DHCP.

This setting is off by default because for simple OP-TEE testing and development, it is not required, and we'd rather have a smaller image that builds and boots faster.

The kernel log level is set to 6 (KERN_INFO) instead of the default 7 (KERN_DEBUG) to avoid many messages from drivers which otherwise would disturb the session. They can still be seen with dmesg.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
