### PR TITLE
Alignment with trusted-services changes

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -4,10 +4,10 @@ FVP_VIRTFS_AUTOMOUNT		?= y
 MEASURED_BOOT			?= y
 MEASURED_BOOT_FTPM		?= n
 TS_SMM_GATEWAY			?= y
-TS_UEFI_TESTS			?= y
+TS_UEFI_TESTS			?= n
 # Supported values: embedded, fip
 SP_PACKAGING_METHOD		?= embedded
-SPMC_TESTS			?= y
+SPMC_TESTS			?= n
 
 # TS SP configurations
 DEFAULT_SP_CONFIG		?= default-opteesp

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -9,6 +9,15 @@ TS_UEFI_TESTS			?= y
 SP_PACKAGING_METHOD		?= embedded
 SPMC_TESTS			?= y
 
+# TS SP configurations
+DEFAULT_SP_CONFIG		?= default-opteesp
+SP_BLOCK_STORAGE_CONFIG	?= $(DEFAULT_SP_CONFIG)
+SP_PSA_ITS_CONFIG		?= $(DEFAULT_SP_CONFIG)
+SP_PSA_PS_CONFIG		?= $(DEFAULT_SP_CONFIG)
+SP_PSA_CRYPTO_CONFIG		?= $(DEFAULT_SP_CONFIG)
+SP_PSA_ATTESTATION_CONFIG	?= $(DEFAULT_SP_CONFIG)
+SP_SMM_GATEWAY_CONFIG		?= $(DEFAULT_SP_CONFIG)
+
 TF_A_FLAGS ?= \
 	BL32=$(OPTEE_OS_PAGER_V2_BIN) \
 	BL33=$(EDK2_BIN) \
@@ -30,15 +39,15 @@ OPTEE_OS_COMMON_EXTRA_FLAGS += \
 
 # The boot order of the SPs is determined by the order of calls here. This is
 # due to the SPMC not (yet) supporting the boot order field of the SP manifest.
-$(eval $(call build-sp,block-storage,config/default-opteesp,63646e80-eb52-462f-ac4f-8cdf3987519c,$(SP_BLOCK_STORAGE_EXTRA_FLAGS)))
-$(eval $(call build-sp,internal-trusted-storage,config/shared-flash-opteesp,dc1eef48-b17a-4ccf-ac8b-dfcff7711b14,$(SP_PSA_ITS_EXTRA_FLAGS)))
-$(eval $(call build-sp,protected-storage,config/shared-flash-opteesp,751bf801-3dde-4768-a514-0f10aeed1790,$(SP_PSA_PS_EXTRA_FLAGS)))
-$(eval $(call build-sp,crypto,config/default-opteesp,d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0,$(SP_PSA_CRYPTO_EXTRA_FLAGS)))
+$(eval $(call build-sp,block-storage,config/$(SP_BLOCK_STORAGE_CONFIG),63646e80-eb52-462f-ac4f-8cdf3987519c,$(SP_BLOCK_STORAGE_EXTRA_FLAGS)))
+$(eval $(call build-sp,internal-trusted-storage,config/$(SP_PSA_ITS_CONFIG),dc1eef48-b17a-4ccf-ac8b-dfcff7711b14,$(SP_PSA_ITS_EXTRA_FLAGS)))
+$(eval $(call build-sp,protected-storage,config/$(SP_PSA_PS_CONFIG),751bf801-3dde-4768-a514-0f10aeed1790,$(SP_PSA_PS_EXTRA_FLAGS)))
+$(eval $(call build-sp,crypto,config/$(SP_PSA_CRYPTO_CONFIG),d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0,$(SP_PSA_CRYPTO_EXTRA_FLAGS)))
 ifeq ($(MEASURED_BOOT),y)
-$(eval $(call build-sp,attestation,config/default-opteesp,a1baf155-8876-4695-8f7c-54955e8db974,$(SP_PSA_ATTESTATION_EXTRA_FLAGS)))
+$(eval $(call build-sp,attestation,config/$(SP_PSA_ATTESTATION_CONFIG),a1baf155-8876-4695-8f7c-54955e8db974,$(SP_PSA_ATTESTATION_EXTRA_FLAGS)))
 endif
 ifeq ($(TS_SMM_GATEWAY),y)
-$(eval $(call build-sp,smm-gateway,config/default-opteesp,ed32d533-99e6-4209-9cc0-2d72cdd998a7,$(SP_SMM_GATEWAY_EXTRA_FLAGS)))
+$(eval $(call build-sp,smm-gateway,config/$(SP_SMM_GATEWAY_CONFIG),ed32d533-99e6-4209-9cc0-2d72cdd998a7,$(SP_SMM_GATEWAY_EXTRA_FLAGS)))
 endif
 
 $(eval $(call build-ts-app,libts))

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -30,14 +30,15 @@ OPTEE_OS_COMMON_EXTRA_FLAGS += \
 
 # The boot order of the SPs is determined by the order of calls here. This is
 # due to the SPMC not (yet) supporting the boot order field of the SP manifest.
-$(eval $(call build-sp,internal-trusted-storage,dc1eef48-b17a-4ccf-ac8b-dfcff7711b14,$(SP_PSA_ITS_EXTRA_FLAGS)))
-$(eval $(call build-sp,protected-storage,751bf801-3dde-4768-a514-0f10aeed1790,$(SP_PSA_PS_EXTRA_FLAGS)))
-$(eval $(call build-sp,crypto,d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0,$(SP_PSA_CRYPTO_EXTRA_FLAGS)))
+$(eval $(call build-sp,block-storage,config/default-opteesp,63646e80-eb52-462f-ac4f-8cdf3987519c,$(SP_BLOCK_STORAGE_EXTRA_FLAGS)))
+$(eval $(call build-sp,internal-trusted-storage,config/shared-flash-opteesp,dc1eef48-b17a-4ccf-ac8b-dfcff7711b14,$(SP_PSA_ITS_EXTRA_FLAGS)))
+$(eval $(call build-sp,protected-storage,config/shared-flash-opteesp,751bf801-3dde-4768-a514-0f10aeed1790,$(SP_PSA_PS_EXTRA_FLAGS)))
+$(eval $(call build-sp,crypto,config/default-opteesp,d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0,$(SP_PSA_CRYPTO_EXTRA_FLAGS)))
 ifeq ($(MEASURED_BOOT),y)
-$(eval $(call build-sp,attestation,a1baf155-8876-4695-8f7c-54955e8db974,$(SP_PSA_ATTESTATION_EXTRA_FLAGS)))
+$(eval $(call build-sp,attestation,config/default-opteesp,a1baf155-8876-4695-8f7c-54955e8db974,$(SP_PSA_ATTESTATION_EXTRA_FLAGS)))
 endif
 ifeq ($(TS_SMM_GATEWAY),y)
-$(eval $(call build-sp,smm-gateway,ed32d533-99e6-4209-9cc0-2d72cdd998a7,$(SP_SMM_GATEWAY_EXTRA_FLAGS)))
+$(eval $(call build-sp,smm-gateway,config/default-opteesp,ed32d533-99e6-4209-9cc0-2d72cdd998a7,$(SP_SMM_GATEWAY_EXTRA_FLAGS)))
 endif
 
 $(eval $(call build-ts-app,libts))
@@ -53,7 +54,7 @@ $(eval $(call build-ts-app,uefi-test))
 endif
 ifeq ($(SPMC_TESTS), y)
 OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
-$(eval $(call build-sp,spm-test1,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
-$(eval $(call build-sp,spm-test2,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
-$(eval $(call build-sp,spm-test3,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test1,opteesp,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test2,opteesp,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test3,opteesp,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 endif

--- a/fvp.mk
+++ b/fvp.mk
@@ -147,7 +147,8 @@ TF_A_FLAGS ?= \
 	SPD=opteed
 
 ifneq ($(MEASURED_BOOT),y)
-	TF_A_FLAGS += DEBUG=$(DEBUG)
+	TF_A_FLAGS += DEBUG=$(DEBUG) \
+		          MEASURED_BOOT=0
 else
 	TF_A_FLAGS += DEBUG=0 \
 		      MBEDTLS_DIR=$(ROOT)/mbedtls  \

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -1,11 +1,16 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  */
+
+block_storage {
+	uuid = "63646e80-eb52-462f-ac4f-8cdf3987519c";
+	load-address = <0x7a00000>;
+};
 
 internal_trusted_storage {
 	uuid = "dc1eef48-b17a-4ccf-ac8b-dfcff7711b14";
-	load-address = <0x7a00000>;
+	load-address = <0x7a80000>;
 };
 
 protected_storage_sp {
@@ -15,17 +20,17 @@ protected_storage_sp {
 
 crypto_sp {
 	uuid = "d9df52d5-16a2-4bb2-9aa4-d26d3b84e8c0";
-	load-address = <0x7c00000>;
+	load-address = <0x7b80000>;
 };
 
 #if MEASURED_BOOT
 initial_attestation_sp {
 	uuid = "a1baf155-8876-4695-8f7c-54955e8db974";
-	load-address = <0x7d00000>;
+	load-address = <0x7c80000>;
 };
 #endif
 
 smm_gateway {
 	uuid = "ed32d533-99e6-4209-9cc0-2d72cdd998a7";
-	load-address = <0x7e00000>;
+	load-address = <0x7d00000>;
 };

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  */
 
 /dts-v1/;
@@ -37,9 +37,14 @@
 #ifdef ARM_BL2_SP_LIST_DTS
 	sp_packages {
 		compatible = "arm,sp_pkg";
+		block_storage {
+			uuid = <0x806e6463 0x2f4652eb 0xdf8c4fac 0x9c518739>;
+			load-address = <0x0 0x7a00000>;
+		};
+
 		internal_trusted_storage {
 			uuid = <0x48ef1edc 0xcf4c7ab1 0xcfdf8bac 0x141b71f7>;
-			load-address = <0x0 0x7a00000>;
+			load-address = <0x0 0x7a80000>;
 		};
 
 		protected_storage_sp {
@@ -49,19 +54,19 @@
 
 		crypto_sp {
 			uuid = <0xd552dfd9 0xb24ba216 0x6dd2a49a 0xc0e8843b>;
-			load-address = <0x0 0x7c00000>;
+			load-address = <0x0 0x7b80000>;
 		};
 
 #if MEASURED_BOOT
 		initial_attestation_sp {
 			uuid = <0x55f1baa1 0x95467688 0x95547c8f 0x74b98d5e>;
-			load-address = <0x0 0x7d00000>;
+			load-address = <0x0 0x7c80000>;
 		};
 #endif
 
 		smm_gateway {
 			uuid = <0x33d532ed 0x0942e699 0x722dc09c 0xa798d9cd>;
-			load-address = <0x0 0x7e00000>;
+			load-address = <0x0 0x7d00000>;
 		};
 	};
 #endif

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -87,9 +87,6 @@ else ifeq ($(SP_PACKAGING_METHOD),fip)
 # Configure TF-A to load the SPs from FIP by BL2
 TF_A_FIP_SP_FLAGS += ARM_BL2_SP_LIST_DTS=$(ROOT)/build/fvp/bl2_sp_list.dtsi \
 		SP_LAYOUT_FILE=$(TS_INSTALL_PREFIX)/$(SP_DIR)/json/sp_layout.json
-
-# This should be removed when TF-A is updated to v2.7 or later
-$(call force,MEASURED_BOOT,n,Need TF-A v2.7 for FIP SPs with Measured Boot)
 endif
 
 ################################################################################

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -31,18 +31,19 @@ endif
 #
 # Parameter list:
 # 1 - SP deployment name (e.g. internal-trusted-storage, crypto, etc.)
-# 2 - SP canonical UUID (e.g. dc1eef48-b17a-4ccf-ac8b-dfcff7711b14)
-# 3 - SP additional build flags (e.g. -DTS_PLATFORM=<...>)
+# 2 - Build configuration name (e.g. config/shared-flash)
+# 3 - SP canonical UUID (e.g. dc1eef48-b17a-4ccf-ac8b-dfcff7711b14)
+# 4 - SP additional build flags (e.g. -DTS_PLATFORM=<...>)
 define build-sp
 .PHONY: ffa-$1-sp
 ffa-$1-sp:
 	CROSS_COMPILE=$(subst $(CCACHE),,$(CROSS_COMPILE_S_USER)) cmake -G"Unix Makefiles" \
-		-S $(TS_PATH)/deployments/$1/opteesp -B $(TS_BUILD_PATH)/$1 \
+		-S $(TS_PATH)/deployments/$1/$2 -B $(TS_BUILD_PATH)/$1 \
 		-DCMAKE_INSTALL_PREFIX=$(TS_INSTALL_PREFIX) \
-		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) $(SP_COMMON_FLAGS) $3
+		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) $(SP_COMMON_FLAGS) $4
 	$$(MAKE) -C $(TS_BUILD_PATH)/$1 install
-	dtc -I dts -O dtb -o $(TS_INSTALL_PREFIX)/opteesp/manifest/$2.dtb \
-				$(TS_INSTALL_PREFIX)/opteesp/manifest/$2.dts
+	dtc -I dts -O dtb -o $(TS_INSTALL_PREFIX)/opteesp/manifest/$3.dtb \
+				$(TS_INSTALL_PREFIX)/opteesp/manifest/$3.dts
 
 .PHONY: ffa-$1-sp-clean
 ffa-$1-sp-clean:
@@ -56,7 +57,7 @@ ffa-sp-all: ffa-$1-sp
 ffa-sp-all-clean: ffa-$1-sp-clean
 ffa-sp-all-realclean: ffa-$1-sp-realclean
 
-optee_os_sp_paths += $(TS_INSTALL_PREFIX)/opteesp/bin/$2.stripped.elf
+optee_os_sp_paths += $(TS_INSTALL_PREFIX)/opteesp/bin/$3.stripped.elf
 endef
 
 ifeq ($(SP_PACKAGING_METHOD),embedded)


### PR DESCRIPTION
This pull request multiple changes which are related to the recent changes around the trusted-services project.

- Setting MEASURED_BOOT=n causes TF-A build to fail as it expects a 0/1 value. The first patch fixes this issue.
- Block storage SP was added.
- The trusted-services deployments have been restructured, so the build repo has to follow the new directory structure and enable selecting different SP configurations.
- After updating TF-A to v2.8 the measured boot feature can be enabled with FIP stored SPs.
- Disable UEFI and SPMC tests by default because they require debugging features enabled.