### PR TITLE
qemu, qemu_v8: pass arguments to qemu_check.exp for example to exclude tests

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -8,13 +8,14 @@
 #   -q        Suppress output to stdout (quiet)
 #   --tests   Type of tests to run, values: all, xtest and trusted-keys
 #   --timeout Timeout for each test (sub)case, in seconds [480]
+#   --xtest-args Optional arguments to xtest
 
 set bios "../out/bios-qemu/bios.bin"
-set cmd "xtest"
 set cmd1 "cd /mnt/host/build/qemu_v8/xen"
 set cmd2 "xl create guest.cfg"
 set cmd3 "xl console domu"
 set quiet 0
+set xtest_args ""
 
 # The time required to run some tests (e.g., key generation tests [4007.*])
 # can be significant and vary widely -- typically, from about one minute to
@@ -33,8 +34,11 @@ while {[llength $myargs]} {
 		"--tests"	{set myargs [lassign $myargs ::tests]}
 		"--timeout"	{set myargs [lassign $myargs ::timeout]}
 		"-q"		{set ::quiet 1}
+		"--xtest-args"  {set myargs [lassign $myargs ::xtest_args]}
 	}
 }
+
+set cmd "xtest $xtest_args"
 
 proc info arg {
 	if {$::quiet==1} { return }

--- a/qemu.mk
+++ b/qemu.mk
@@ -185,6 +185,9 @@ endif
 ifneq ($(CHECK_TESTS),)
 check-args += --tests $(CHECK_TESTS)
 endif
+ifneq ($(XTEST_ARGS),)
+check-args += --xtest-args "$(XTEST_ARGS)"
+endif
 
 check: $(CHECK_DEPS)
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -456,6 +456,9 @@ endif
 ifneq ($(CHECK_TESTS),)
 check-args += --tests $(CHECK_TESTS)
 endif
+ifneq ($(XTEST_ARGS),)
+check-args += --xtest-args "$(XTEST_ARGS)"
+endif
 
 check: $(CHECK_DEPS)
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/


### PR DESCRIPTION
This commit adds a way to exclude tests when running the xtest suite:
- qemu_check.exp now supports "--xtest-args <args>", which passes <args> to the xtest command,
- The CHECK_ARGS make variable is passed to qemu_check.exp.

For example to run the whole test suite but exclude xtest regression_1031:

 $ make check CHECK_ARGS="--xtest-args '-x regression_1031'"

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
