### PR TITLE
Versal ACAP: bootgen image file

### DIFF
--- a/versal/bootImage-versal-vck190.bif
+++ b/versal/bootImage-versal-vck190.bif
@@ -11,6 +11,6 @@ the_ROM_image:
 	      { type=raw, load=0x00001000, file=../u-boot/arch/arm/dts/versal-vck190-revA-x-ebm-01-revA.dtb }
 	      { core=a72-0, exception_level=el-3, trustzone, file=../arm-trusted-firmware/build/versal/debug/bl31/bl31.elf }
 	      { core=a72-0, exception_level=el-2, file=../u-boot/u-boot.elf }
-	      { core=a72-0, exception_level=el-1, trustzone, load=0x60000000, startup=0x60000000, file=../optee_os/out/arm/core/tee-raw.bin }
+	      { type=raw, load=0x60000000, file=../optee_os/out/arm/core/tee-raw.bin }
 	}
 }


### PR DESCRIPTION
Until Bootgen/PLM supports booting OP-TEE, it is TF-A's responsibility to do it..

The PLM simply loads the raw image into the location agreed with TF-A at build time.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
