### PR TITLE
optee_rust: change toolchain path searching priority

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -296,7 +296,7 @@ ifeq ($(OPTEE_RUST_ENABLE),y)
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT ?= y
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_CROSS_COMPILE ?= $(CROSS_COMPILE_S_USER)
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_SITE ?= $(OPTEE_RUST_PATH)
-BR2_PACKAGE_OPTEE_RUST_EXAMPLES_TC_PATH_ENV = $(PATH):$(ROOT)/toolchains/aarch64/bin:$(HOME)/.cargo/bin
+BR2_PACKAGE_OPTEE_RUST_EXAMPLES_TC_PATH_ENV = $(ROOT)/toolchains/aarch64/bin:$(HOME)/.cargo/bin:$(PATH)
 endif
 # The OPTEE_OS package builds nothing, it just installs files into the
 # root FS when applicable (for example: shared libraries)


### PR DESCRIPTION
Use the toolchains in OP-TEE repo instead of those in $PATH, to avoid potential inconsistency of toolchains.

Related issue: https://github.com/OP-TEE/build/issues/624

Signed-off-by: Yuan Zhuang <demesne@foxmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
