### PR TITLE
fvp: enable passing extra arguments

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -329,4 +329,4 @@ FVP_ARGS ?= \
 endif
 
 run-only:
-	$(FVP_PATH)/$(FVP_BIN) $(FVP_ARGS)
+	$(FVP_PATH)/$(FVP_BIN) $(FVP_ARGS) $(FVP_EXTRA_ARGS)


### PR DESCRIPTION
Introduce a new variable to allow passing extra arguments to the FVP with environment variable or on the make command line. As an example this allows passing trace related configuration.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
