### PR TITLE
Enhance and fix TS NWd build integration 

### DIFF
--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -160,9 +160,15 @@ ffa-$1:
 	CROSS_COMPILE=$(subst $(CCACHE),,$(CROSS_COMPILE_NS_USER)) cmake -G"Unix Makefiles" \
 		-S $(TS_PATH)/deployments/$1/arm-linux -B $(TS_BUILD_PATH)/$1 \
 		-DCMAKE_INSTALL_PREFIX=$(TS_INSTALL_PREFIX) \
+		-Dlibts_DIR=${TS_INSTALL_PREFIX}/arm-linux/lib/cmake/libts \
+		-DCFG_FORCE_PREBUILT_LIBTS=On \
 		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) $(TS_APP_COMMON_FLAGS) \
 		$(TS_APP_${FFA_$1_UC_NAME}_EXTRA_FLAGS)
 	$$(MAKE) -C $(TS_BUILD_PATH)/$1 install
+
+ifneq ($1,libts)
+ffa-$1: ffa-libts
+endif
 
 .PHONY: ffa-$1-clean
 ffa-$1-clean:

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -143,13 +143,25 @@ endif
 
 # Helper macro to build and install Trusted Services test applications.
 # Invokes CMake to configure, and make to build and install the apps.
+#
+# Parameter list:
+# 1 - SP deployment name (e.g. psa-api-test/internal-trusted-storage,
+#     ts-demo, etc.)
+#
+# Each target will pass TS_APP_COMMON_FLAGS and
+# TS_APP_<ucfdpn>_EXTRA_FLAGS to cmake. ucfdpn is the upper case
+# deployment name with all / characters replaced by _ characters. These
+# variables allow setting extra build flags trough the environment.
+
 define build-ts-app
 .PHONY: ffa-$1
+FFA_$1_UC_NAME:=$(shell echo $1 | tr a-z/ A-Z_)
 ffa-$1:
 	CROSS_COMPILE=$(subst $(CCACHE),,$(CROSS_COMPILE_NS_USER)) cmake -G"Unix Makefiles" \
 		-S $(TS_PATH)/deployments/$1/arm-linux -B $(TS_BUILD_PATH)/$1 \
 		-DCMAKE_INSTALL_PREFIX=$(TS_INSTALL_PREFIX) \
-		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE)
+		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) $(TS_APP_COMMON_FLAGS) \
+		$(TS_APP_${FFA_$1_UC_NAME}_EXTRA_FLAGS)
 	$$(MAKE) -C $(TS_BUILD_PATH)/$1 install
 
 .PHONY: ffa-$1-clean


### PR DESCRIPTION
This PR:
-  enhances Trusted Services integration by allowing to pass extra arguments to cmake when building NWd executables. This comes handy when a layer above the build repo (e.g. CI system) needs to control the arguments.
- fixes the libts dependency handling of NWd executables. The current implementation is buggy and the intended build optimization does not work. See the commit message of the second commit for details.