### PR TITLE
ffa: Allow multiple SPs with same UUID

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -12,6 +12,8 @@ SPMC_TESTS			?= n
 # Enable the "HArdware Volatile Entropy Gathering and Expansion" daemon to
 # overcome low-entropy conditions in the FVP
 BR2_PACKAGE_HAVEGED		?= y
+SPMC_TESTS			?= y
+TS_RPC_UUID			?= y
 
 # TS SP configurations
 DEFAULT_SP_CONFIG		?= default-opteesp
@@ -40,6 +42,17 @@ OPTEE_OS_COMMON_EXTRA_FLAGS += \
 	CFG_CORE_HEAP_SIZE=131072 \
 	CFG_DT=y \
 	CFG_MAP_EXT_DT_SECURE=y
+
+
+ifeq ($(TS_RPC_UUID),y)
+TS_RPC_UUID="bdcd76d7-825e-4751-963b-86d4f84943ac"
+SP_BLOCK_STORAGE_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+SP_PSA_ITS_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+SP_PSA_PS_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+SP_PSA_CRYPTO_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+SP_PSA_ATTESTATION_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+SP_SMM_GATEWAY_EXTRA_FLAGS +=-DTS_RPC_UUID=$(TS_RPC_UUID)
+endif
 
 # The boot order of the SPs is determined by the order of calls here. This is
 # due to the SPMC not (yet) supporting the boot order field of the SP manifest.

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -70,4 +70,5 @@ OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
 $(eval $(call build-sp,spm-test1,opteesp,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test2,opteesp,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test3,opteesp,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test4,opteesp,423762ed-7772-406f-99d8-0c27da0abbf8,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 endif

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -53,4 +53,9 @@ test_sp3 {
 	load-address = <0x7a20000>;
 };
 
+test_sp4 {
+	/* FF-A UUID */
+	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
+	load-address = <0x7a30000>;
+};
 #endif

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -3,6 +3,7 @@
  * Copyright (c) 2022-2023, Arm Limited. All rights reserved.
  */
 
+#if !SPMC_TESTS
 block_storage {
 	uuid = "63646e80-eb52-462f-ac4f-8cdf3987519c";
 	load-address = <0x7a00000>;
@@ -34,3 +35,22 @@ smm_gateway {
 	uuid = "ed32d533-99e6-4209-9cc0-2d72cdd998a7";
 	load-address = <0x7d00000>;
 };
+
+#else
+
+test_sp1 {
+	uuid = "5c9edbc3-7b3a-4367-9f83-7c191ae86a37";
+	load-address = <0x7a00000>;
+};
+
+test_sp2 {
+	uuid = "7817164c-c40c-4d1a-867a-9bb2278cf41a";
+	load-address = <0x7a10000>;
+};
+
+test_sp3 {
+	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
+	load-address = <0x7a20000>;
+};
+
+#endif

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -85,6 +85,11 @@
 			load-address = <0x0 0x7a20000>;
 		};
 
+		test_sp4 {
+			/* SP binary UUID */
+			uuid = <0xed623742 0x6f407277 0x270cd899 0xf8bb0ada>;
+			load-address = <0x0 0x7a30000>;
+		};
 #endif
 
 	};

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -37,11 +37,11 @@
 #ifdef ARM_BL2_SP_LIST_DTS
 	sp_packages {
 		compatible = "arm,sp_pkg";
+#if !SPMC_TESTS
 		block_storage {
 			uuid = <0x806e6463 0x2f4652eb 0xdf8c4fac 0x9c518739>;
 			load-address = <0x0 0x7a00000>;
 		};
-
 		internal_trusted_storage {
 			uuid = <0x48ef1edc 0xcf4c7ab1 0xcfdf8bac 0x141b71f7>;
 			load-address = <0x0 0x7a80000>;
@@ -68,6 +68,25 @@
 			uuid = <0x33d532ed 0x0942e699 0x722dc09c 0xa798d9cd>;
 			load-address = <0x0 0x7d00000>;
 		};
+
+#else /*BUILD_SPMC_TESTS*/
+		test_sp1 {
+			uuid = <0xc3db9e5c 0x67433a7b 0x197c839f 0x376ae81a>;
+			load-address = <0x0 0x7a00000>;
+		};
+
+		test_sp2 {
+			uuid = <0x4c161778 0x1a4d0cc4 0xb29b7a86 0x1af48c27>;
+			load-address = <0x0 0x7a10000>;
+		};
+
+		test_sp3 {
+			uuid = <0x0001eb23 0x97442ae3 0x112f5290 0xa6af84e5>;
+			load-address = <0x0 0x7a20000>;
+		};
+
+#endif
+
 	};
 #endif
 };

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -115,7 +115,8 @@ linux-arm-ffa-user: linux
 	echo "ed32d533-99e6-4209-9cc0-2d72cdd998a7,\
 	5c9edbc3-7b3a-4367-9f83-7c191ae86a37,\
 	7817164c-c40c-4d1a-867a-9bb2278cf41a,\
-	23eb0100-e32a-4497-9052-2f11e584afa6" > \
+	23eb0100-e32a-4497-9052-2f11e584afa6,\
+	bdcd76d7-825e-4751-963b-86d4f84943ac" > \
 		$(OUT_PATH)/linux-arm-ffa-user/sp_uuid_list.txt
 
 linux-arm-ffa-user-clean:


### PR DESCRIPTION
Change the naming scheme of the SP binaries to make sure we can add multiple SPs with the same UUID to the system. Added the possibility to compile all TS SPs with the same FF-A UUID (protocol UUID).
This is need to support [5898](https://github.com/OP-TEE/optee_os/pull/5898)
This is a follow-up on [603](https://github.com/OP-TEE/build/pull/603)
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
