### PR TITLE
Fix: SPMC test shall build arm-ffa-user driver

### DIFF
--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -103,8 +103,8 @@ linux-arm-ffa-tee: linux
 linux-arm-ffa-tee-clean:
 	$(MAKE) -C $(ROOT)/linux-arm-ffa-tee clean
 
-# This driver is only used by the uefi-test app
-ifeq ($(TS_UEFI_TESTS),y)
+# This driver is only used by the uefi-test app or the spmc tests
+ifneq ($(filter y, $(TS_UEFI_TESTS) $(SPMC_TESTS)),)
 .PHONY: linux-arm-ffa-user linux-arm-ffa-user-clean
 all: linux-arm-ffa-user
 


### PR DESCRIPTION
x-test uses the arm-ffa-user driver to talk to the SPMC test SPs, but the driver build was not triggered when SPMC_TESTS is enabled. This change ensures arm-ffa-uses is built when SPMC_TESTS is set to y.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
