### PR TITLE
ts: Generate sp_layout.json after SP builds

### DIFF
--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -78,15 +78,21 @@ ffa-sp-all-clean: ffa-$1-sp-clean
 ffa-sp-all-realclean: ffa-$1-sp-realclean
 
 optee_os_sp_paths += $(TS_INSTALL_PREFIX)/$(SP_DIR)/bin/$3.$(SP_EXT)
+fip_sp_json_paths += $(TS_INSTALL_PREFIX)/$(SP_DIR)/json/$1.json
 endef
 
 ifeq ($(SP_PACKAGING_METHOD),embedded)
 # Add the list of SP paths to the optee_os config
 OPTEE_OS_COMMON_EXTRA_FLAGS += SP_PATHS="$(optee_os_sp_paths)"
 else ifeq ($(SP_PACKAGING_METHOD),fip)
+$(TS_INSTALL_PREFIX)/sp_layout.json: ffa-sp-all
+	python $(TS_PATH)/tools/python/merge_json.py $@ $(fip_sp_json_paths)
+
+optee-os-common: $(TS_INSTALL_PREFIX)/sp_layout.json
+
 # Configure TF-A to load the SPs from FIP by BL2
 TF_A_FIP_SP_FLAGS += ARM_BL2_SP_LIST_DTS=$(ROOT)/build/fvp/bl2_sp_list.dtsi \
-		SP_LAYOUT_FILE=$(TS_INSTALL_PREFIX)/$(SP_DIR)/json/sp_layout.json
+		SP_LAYOUT_FILE=$(TS_INSTALL_PREFIX)/sp_layout.json
 endif
 
 ################################################################################


### PR DESCRIPTION
TF-A requires to have the SPs in the same order in the FIP as it is defined in ARM_BL2_SP_LIST_DTS. The sp_layout.json controls the order of SPs in the FIP package. Previously the individual JSON fragments were appended to the sp_layout.json file at the end of the SP build. The final order of SP definitions in the sp_layout.json depended on the SP build order which was non-deterministic because of the parallel make jobs. To resolve this issue the JSON merging step is now done after all SPs have been built. The order will follow the order of build-sp calls in the fvp-psa-sp.mk which matches the order of SPs in ARM_BL2_SP_LIST_DTS.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
