### PR TITLE
fvp: SP configuration fixes

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,6 +24,7 @@ endef
 
 SHELL := bash
 BASH ?= bash
+PYTHON3 ?= python3
 ROOT ?= $(shell pwd)/..
 
 UNAME_M				:= $(shell uname -m)
@@ -344,7 +345,7 @@ buildroot: optee-os optee-rust
 	@rm -f ../out-br/build/optee_*/.stamp_*
 	@rm -f ../out-br/extra.conf
 	@$(call append-br2-vars,../out-br/extra.conf)
-	@(cd .. && python build/br-ext/scripts/make_def_config.py \
+	@(cd .. && $(PYTHON3) build/br-ext/scripts/make_def_config.py \
 		--br buildroot --out out-br --br-ext build/br-ext \
 		--top-dir "$(ROOT)" \
 		--br-defconfig build/br-ext/configs/optee_$(BUILDROOT_ARCH) \
@@ -373,7 +374,7 @@ buildroot-domu: optee-os
 	@rm -f ../out-br-domu/build/optee_*/.stamp_*
 	@rm -f ../out-br-domu/extra.conf
 	@$(call append-br2-vars,../out-br-domu/extra.conf)
-	@(cd .. && python build/br-ext/scripts/make_def_config.py \
+	@(cd .. && $(PYTHON3) build/br-ext/scripts/make_def_config.py \
 		--br buildroot --out out-br-domu --br-ext build/br-ext \
 		--top-dir "$(ROOT)" \
 		--br-defconfig build/br-ext/configs/optee_$(BUILDROOT_ARCH) \

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -36,6 +36,19 @@ TF_A_FLAGS ?= \
 include fvp.mk
 include trusted-services.mk
 
+# The macros used in bl2_sp_list.dts and spmc_manifest.dts has to be passed to
+# TF-A because it handles the preprocessing of these files.
+define add-dtc-define
+DTC_CPPFLAGS+=-D$1=$(subst y,1,$(subst n,0,$($1)))
+endef
+
+ifeq ($(SP_PACKAGING_METHOD),fip)
+$(eval $(call add-dtc-define,SPMC_TESTS))
+$(eval $(call add-dtc-define,TS_SMM_GATEWAY))
+
+TF_A_EXPORTS += DTC_CPPFLAGS="$(DTC_CPPFLAGS)"
+endif
+
 OPTEE_OS_COMMON_EXTRA_FLAGS += \
 	CFG_SECURE_PARTITION=y \
 	CFG_CORE_SEL1_SPMC=y \

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -12,8 +12,7 @@ SPMC_TESTS			?= n
 # Enable the "HArdware Volatile Entropy Gathering and Expansion" daemon to
 # overcome low-entropy conditions in the FVP
 BR2_PACKAGE_HAVEGED		?= y
-SPMC_TESTS			?= y
-TS_RPC_UUID			?= y
+TS_RPC_UUID			?= n
 
 # TS SP configurations
 DEFAULT_SP_CONFIG		?= default-opteesp
@@ -45,6 +44,7 @@ endef
 ifeq ($(SP_PACKAGING_METHOD),fip)
 $(eval $(call add-dtc-define,SPMC_TESTS))
 $(eval $(call add-dtc-define,TS_SMM_GATEWAY))
+$(eval $(call add-dtc-define,TS_RPC_UUID))
 
 TF_A_EXPORTS += DTC_CPPFLAGS="$(DTC_CPPFLAGS)"
 endif
@@ -87,7 +87,9 @@ OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
 $(eval $(call build-sp,spm-test1,opteesp,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test2,opteesp,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 $(eval $(call build-sp,spm-test3,opteesp,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+ifeq ($(TS_RPC_UUID),y)
 $(eval $(call build-sp,spm-test4,opteesp,423762ed-7772-406f-99d8-0c27da0abbf8,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+endif
 endif
 
 # Linux user space applications

--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -56,6 +56,8 @@ endif
 
 # The boot order of the SPs is determined by the order of calls here. This is
 # due to the SPMC not (yet) supporting the boot order field of the SP manifest.
+ifeq ($(SPMC_TESTS),n)
+# PSA SPs
 $(eval $(call build-sp,block-storage,config/$(SP_BLOCK_STORAGE_CONFIG),63646e80-eb52-462f-ac4f-8cdf3987519c,$(SP_BLOCK_STORAGE_EXTRA_FLAGS)))
 $(eval $(call build-sp,internal-trusted-storage,config/$(SP_PSA_ITS_CONFIG),dc1eef48-b17a-4ccf-ac8b-dfcff7711b14,$(SP_PSA_ITS_EXTRA_FLAGS)))
 $(eval $(call build-sp,protected-storage,config/$(SP_PSA_PS_CONFIG),751bf801-3dde-4768-a514-0f10aeed1790,$(SP_PSA_PS_EXTRA_FLAGS)))
@@ -66,7 +68,17 @@ endif
 ifeq ($(TS_SMM_GATEWAY),y)
 $(eval $(call build-sp,smm-gateway,config/$(SP_SMM_GATEWAY_CONFIG),ed32d533-99e6-4209-9cc0-2d72cdd998a7,$(SP_SMM_GATEWAY_EXTRA_FLAGS)))
 endif
+else
+# SPMC test SPs
+OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
+$(eval $(call build-sp,spm-test1,opteesp,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test2,opteesp,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test3,opteesp,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+$(eval $(call build-sp,spm-test4,opteesp,423762ed-7772-406f-99d8-0c27da0abbf8,$(SP_SPMC_TEST_EXTRA_FLAGS)))
+endif
 
+# Linux user space applications
+ifeq ($(SPMC_TESTS),n)
 $(eval $(call build-ts-app,libts))
 $(eval $(call build-ts-app,ts-service-test))
 $(eval $(call build-ts-app,psa-api-test/internal_trusted_storage))
@@ -78,10 +90,4 @@ endif
 ifeq ($(TS_UEFI_TESTS),y)
 $(eval $(call build-ts-app,uefi-test))
 endif
-ifeq ($(SPMC_TESTS), y)
-OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_SPMC_TESTS=y
-$(eval $(call build-sp,spm-test1,opteesp,5c9edbc3-7b3a-4367-9f83-7c191ae86a37,$(SP_SPMC_TEST_EXTRA_FLAGS)))
-$(eval $(call build-sp,spm-test2,opteesp,7817164c-c40c-4d1a-867a-9bb2278cf41a,$(SP_SPMC_TEST_EXTRA_FLAGS)))
-$(eval $(call build-sp,spm-test3,opteesp,23eb0100-e32a-4497-9052-2f11e584afa6,$(SP_SPMC_TEST_EXTRA_FLAGS)))
-$(eval $(call build-sp,spm-test4,opteesp,423762ed-7772-406f-99d8-0c27da0abbf8,$(SP_SPMC_TEST_EXTRA_FLAGS)))
 endif

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -55,10 +55,12 @@ test_sp3 {
 	load-address = <0x7a40000>;
 };
 
+#if TS_RPC_UUID
 test_sp4 {
 	/* FF-A UUID */
 	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
 	load-address = <0x7a80000>;
 };
+#endif /* TS_RPC_UUID */
 
 #endif /* SPMC_TESTS */

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -29,14 +29,16 @@ initial_attestation_sp {
 	uuid = "a1baf155-8876-4695-8f7c-54955e8db974";
 	load-address = <0x7c80000>;
 };
-#endif
+#endif /* MEASURED_BOOT */
 
+#if TS_SMM_GATEWAY
 smm_gateway {
 	uuid = "ed32d533-99e6-4209-9cc0-2d72cdd998a7";
 	load-address = <0x7d00000>;
 };
+#endif /* TS_SMM_GATEWAY */
 
-#else
+#else /* SPMC_TESTS */
 
 test_sp1 {
 	uuid = "5c9edbc3-7b3a-4367-9f83-7c191ae86a37";
@@ -58,4 +60,5 @@ test_sp4 {
 	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
 	load-address = <0x7a30000>;
 };
-#endif
+
+#endif /* SPMC_TESTS */

--- a/fvp/bl2_sp_list.dtsi
+++ b/fvp/bl2_sp_list.dtsi
@@ -47,18 +47,18 @@ test_sp1 {
 
 test_sp2 {
 	uuid = "7817164c-c40c-4d1a-867a-9bb2278cf41a";
-	load-address = <0x7a10000>;
+	load-address = <0x7a20000>;
 };
 
 test_sp3 {
 	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
-	load-address = <0x7a20000>;
+	load-address = <0x7a40000>;
 };
 
 test_sp4 {
 	/* FF-A UUID */
 	uuid = "23eb0100-e32a-4497-9052-2f11e584afa6";
-	load-address = <0x7a30000>;
+	load-address = <0x7a80000>;
 };
 
 #endif /* SPMC_TESTS */

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -79,18 +79,18 @@
 
 		test_sp2 {
 			uuid = <0x4c161778 0x1a4d0cc4 0xb29b7a86 0x1af48c27>;
-			load-address = <0x0 0x7a10000>;
+			load-address = <0x0 0x7a20000>;
 		};
 
 		test_sp3 {
 			uuid = <0x0001eb23 0x97442ae3 0x112f5290 0xa6af84e5>;
-			load-address = <0x0 0x7a20000>;
+			load-address = <0x0 0x7a40000>;
 		};
 
 		test_sp4 {
 			/* SP binary UUID */
 			uuid = <0xed623742 0x6f407277 0x270cd899 0xf8bb0ada>;
-			load-address = <0x0 0x7a30000>;
+			load-address = <0x0 0x7a80000>;
 		};
 #endif /* SPMC_TESTS */
 

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -87,11 +87,13 @@
 			load-address = <0x0 0x7a40000>;
 		};
 
+#if TS_RPC_UUID
 		test_sp4 {
 			/* SP binary UUID */
 			uuid = <0xed623742 0x6f407277 0x270cd899 0xf8bb0ada>;
 			load-address = <0x0 0x7a80000>;
 		};
+#endif /* TS_RPC_UUID */
 #endif /* SPMC_TESTS */
 
 	};

--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -64,12 +64,14 @@
 		};
 #endif
 
+#if TS_SMM_GATEWAY
 		smm_gateway {
 			uuid = <0x33d532ed 0x0942e699 0x722dc09c 0xa798d9cd>;
 			load-address = <0x0 0x7d00000>;
 		};
+#endif /* TS_SMM_GATEWAY */
 
-#else /*BUILD_SPMC_TESTS*/
+#else /* SPMC_TESTS */
 		test_sp1 {
 			uuid = <0xc3db9e5c 0x67433a7b 0x197c839f 0x376ae81a>;
 			load-address = <0x0 0x7a00000>;
@@ -90,8 +92,8 @@
 			uuid = <0xed623742 0x6f407277 0x270cd899 0xf8bb0ada>;
 			load-address = <0x0 0x7a30000>;
 		};
-#endif
+#endif /* SPMC_TESTS */
 
 	};
-#endif
+#endif /* ARM_BL2_SP_LIST_DTS */
 };

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -30,7 +30,7 @@ endef
 define build_toolchain
 	@echo Building $1 toolchain
 	@mkdir -p ../out-$1-sdk $2
-	@(cd .. && python build/br-ext/scripts/make_def_config.py \
+	@(cd .. && $(PYTHON3) build/br-ext/scripts/make_def_config.py \
 		--br buildroot --out out-$1-sdk --br-ext build/br-ext \
 		--top-dir "$(ROOT)" \
 		--br-defconfig build/br-ext/configs/sdk-$1 \

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -86,7 +86,7 @@ ifeq ($(SP_PACKAGING_METHOD),embedded)
 OPTEE_OS_COMMON_EXTRA_FLAGS += SP_PATHS="$(optee_os_sp_paths)"
 else ifeq ($(SP_PACKAGING_METHOD),fip)
 $(TS_INSTALL_PREFIX)/sp_layout.json: ffa-sp-all
-	python $(TS_PATH)/tools/python/merge_json.py $@ $(fip_sp_json_paths)
+	$(PYTHON3) $(TS_PATH)/tools/python/merge_json.py $@ $(fip_sp_json_paths)
 
 optee-os-common: $(TS_INSTALL_PREFIX)/sp_layout.json
 


### PR DESCRIPTION
There are couple issues around TS SPs which this patch intends to fix.

- Aligning selection logic for SPs across fvp-psa-sp.mk, bl2_sp_list.dtsi and spmc_manifest.dts so they all include the same set of SPs for a given configuration.
- Pass DTC_CPPFLAGS to TF-A build because it preprocesses bl2_sp_list.dtsi and spmc_manifest.dts which only works if the necessary defines are forwarded properly.
- Increase SPM test SP memory area because they overlap with the current 64kB setting.
- Make RPC protocol UUID feature backwards compatible