### PR TITLE
rpi3: don't strip kernel8.img

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -22,6 +22,10 @@ BR2_PACKAGE_OPENSSH ?= y
 BR2_PACKAGE_OPENSSH_SERVER ?= y
 BR2_PACKAGE_OPENSSH_KEY_UTILS ?= y
 
+# We don't want buildroot to strip kernel8.img, since that will remove the
+# "magic" from the kernel header.
+BR2_STRIP_EXCLUDE_FILES ?= kernel8.img
+
 OPTEE_OS_PLATFORM = rpi3
 
 include common.mk


### PR DESCRIPTION
In one of the final build stages, buildroot will strip [1] binaries by running the following on all binaries under ./out-br/target:

  $ aarch64-linux-gnu-strip --remove-section=.comment \
    --remove-section=.note

When doing that on kernel8.img (which should be a 1:1 copy of ./linux/arch/arm64/boot/Image), the expected "magic" from the kernel header disappears and so does a few other things as well. In short, the kernel image becomes corrupt. Without the magic, U-boot won't pass execution to Linux and will instead fail with the error message: "Bad Linux ARM64 Image magic!"

To prevent kernel8.img from being stripped, we include it in the BR2_STRIP_EXCLUDE_FILES Makefile parameter.

Why this suddenly started to show, I haven't been able to figure out.

Link: [1] https://github.com/buildroot/buildroot/blob/71a2706320dbc22b16397b70b2d53b903bde0752/Makefile#L620-L650
Fixes: https://github.com/OP-TEE/optee_os/issues/5891


Tested-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
