### PR TITLE
toolchain.mk: do not check server certificate when downloading

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -14,7 +14,7 @@ define dltc
 	@if [ ! -d "$(1)" ]; then \
 		echo "Downloading $(3) ..."; \
 		mkdir -p $(1); \
-		curl --retry 5 -s -S -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz || \
+		curl --retry 5 -k -s -S -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz || \
 			{ rm -f $(TOOLCHAIN_ROOT)/$(3).tar.xz; cd $(TOOLCHAIN_ROOT) && rmdir $(1); echo Download failed; exit 1; }; \
 		tar xf $(TOOLCHAIN_ROOT)/$(3).tar.xz -C $(1) --strip-components=1 || \
 			{ rm $(TOOLCHAIN_ROOT)/$(3).tar.xz; echo Downloaded file is damaged; \


### PR DESCRIPTION
"make toolchains" is now failing with the following error:

 curl: (60) SSL certificate problem: unable to get local issuer certificate
 More details here: https://curl.se/docs/sslcerts.html

 curl failed to verify the legitimacy of the server and therefore could not
 establish a secure connection to it. To learn more about this situation and
 how to fix it, please visit the web page mentioned above.

Although I could download the GCC package [1] just fine with Firefox, the same URL does indeed cause an error when downloaded with curl on my laptop (I am using Ubuntu 22.04.2). The same error happens in the OP-TEE CI loop.

It looks like a required CA certificate ("GlobalSign RSA OV SSL CA 2018") is missing in /etc/ssl/certs/ca-certificates.crt.

Add -k to the curl command to disable certificate verification.

Link: [1] https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
