### PR TITLE
Update hikey.mk

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -134,6 +134,7 @@ endef
 
 .PHONY: edk2
 edk2:
+        sed -i 's/\(^DEFINE GCC_ALL_CC_FLAGS.*-Wno-array-bounds\)/\1 -Wno-stringop-overflow/' $(EDK2_PATH)/BaseTools/Conf/tools_def.template
 	cd $(EDK2_PATH) && rm -rf OpenPlatformPkg && \
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \


### PR DESCRIPTION
Fix the issue about building OP-TEE 3.21.0 for Hikey with the default toolchain version 11.3

Fixed by @jforissier
Tested by Longlong LIAO [liaoll@hku.hk](mailto:liaoll@hku.hk)