### PR TITLE
Fix build of fTPM by enabling build of 32-bit libraries

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -197,7 +197,12 @@ OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_USER_TA_TARGETS=ta_arm32
 endif
 ifeq ($(COMPILE_S_USER),64)
 OPTEE_OS_TA_DEV_KIT_DIR	?= $(OPTEE_OS_PATH)/out/arm/export-ta_arm64
+ifeq ($(MEASURED_BOOT_FTPM),y)
+# The fTPM TA can only be built for 32-bit so enable the 32-bit libraries as well
+OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_USER_TA_TARGETS="ta_arm64 ta_arm32"
+else
 OPTEE_OS_COMMON_EXTRA_FLAGS	+= CFG_USER_TA_TARGETS=ta_arm64
+endif
 endif
 
 ifeq ($(COMPILE_S_KERNEL),64)


### PR DESCRIPTION
Fixes https://github.com/OP-TEE/optee_os/issues/6111

The [fTPM coded by Microsoft](https://github.com/microsoft/ms-tpm-20-ref/tree/main/Samples/ARM32-FirmwareTPM/optee_ta/fTPM) targets 32-bit ARM. Hence, the build requires the 32-bit versions of the libraries it links against. However, at the moment, only the 64-bit versions are generated which makes the build fail.

This PR enables the generation of 32-bit libraries only if the fTPM build is enabled, and disables it otherwise, just as the current behavior.
