### PR TITLE
hikey, hikey960: edk2: fix build error with GCC 11.3

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -134,6 +134,7 @@ endef
 
 .PHONY: edk2
 edk2:
+	sed -i 's/\(^DEFINE GCC_ALL_CC_FLAGS.*-Wno-array-bounds\) -include/\1 -Wno-stringop-overflow -include/' $(EDK2_PATH)/BaseTools/Conf/tools_def.template
 	cd $(EDK2_PATH) && rm -rf OpenPlatformPkg && \
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -130,6 +130,7 @@ endef
 
 .PHONY: edk2
 edk2:
+	sed -i 's/\(^DEFINE GCC_ALL_CC_FLAGS.*-Wno-array-bounds\) -include/\1 -Wno-stringop-overflow -include/' $(EDK2_PATH)/BaseTools/Conf/tools_def.template
 	cd $(EDK2_PATH) && rm -rf OpenPlatformPkg && \
 		ln -s $(OPENPLATPKG_PATH)
 	set -e && cd $(EDK2_PATH) && source edksetup.sh && \


### PR DESCRIPTION
EDK2 fails to build when the cross-compiler is GCC 11.3. The error is as follows:
```
/home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c: In function ‘UsbIoBulkTransfer’: /home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c:259:12: error: ‘UsbHcBulkTransfer’ accessing 80 bytes in a region of size 8 [-Werror=stringop-overflow=]
  259 |   Status  = UsbHcBulkTransfer (
      |            ^~~~~~~~~~~~~~~~~~~~
  260 |               Dev->Bus,
      |               ~~~~~~~~~
  261 |               Dev->Address,
      |               ~~~~~~~~~~~~~
  262 |               Endpoint,
      |               ~~~~~~~~~
  263 |               Dev->Speed,
      |               ~~~~~~~~~~~
  264 |               EpDesc->Desc.MaxPacketSize,
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  265 |               BufNum,
      |               ~~~~~~~
  266 |               &Data,
      |               ~~~~~~
  267 |               DataLength,
      |               ~~~~~~~~~~~
  268 |               &Toggle,
      |               ~~~~~~~~
  269 |               Timeout,
      |               ~~~~~~~~
  270 |               &Dev->Translator,
      |               ~~~~~~~~~~~~~~~~~
  271 |               UsbStatus
      |               ~~~~~~~~~
  272 |               );
      |               ~
/home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c:259:12: note: referencing argument 7 of type ‘void **’
In file included from /home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.h:46,
                 from /home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c:16:
/home/pelops2/hikey960/tee321/edk2/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.h:200:1: note: in a call to function ‘UsbHcBulkTransfer’
  200 | UsbHcBulkTransfer (
      | ^~~~~~~~~~~~~~~~~
...
```
Let's add -Wno-stringop-overflow to avoid that error. The right place for the fix would obviously be the upstream EDK2 repository [1] but since it does not seem to be maintained anymore, patching the file at build time is good enough.

Reported-by: Longlong LIAO <liaoll@hku.hk>
Link: https://github.com/96boards-hikey/edk2.git [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
