### PR TITLE
toolchain.mk: add RISC-V toolchain downloaded from official release

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -5,6 +5,7 @@ SHELL				= /bin/bash
 ROOT				?= $(CURDIR)/..
 TOOLCHAIN_ROOT 			?= $(ROOT)/toolchains
 UNAME_M				:= $(shell uname -m)
+TARGET_ARCH			?= arm
 
 # Download toolchain macro for saving some repetition
 # $(1) is $AARCH.._PATH		: i.e., path to the destination
@@ -44,6 +45,7 @@ define build_toolchain
 endef
 
 ifeq ($(UNAME_M),x86_64)
+ifeq ($(TARGET_ARCH),arm)
 AARCH32_PATH 			?= $(TOOLCHAIN_ROOT)/aarch32
 AARCH32_CROSS_COMPILE 		?= $(AARCH32_PATH)/bin/arm-linux-gnueabihf-
 AARCH32_GCC_VERSION 		?= arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-linux-gnueabihf
@@ -80,6 +82,22 @@ endef
 .PHONY: clang-toolchains
 clang-toolchains:
 	$(call dl-clang,$(CLANG_VER),$(CLANG_PATH))
+
+else ifeq ($(TARGET_ARCH),riscv)
+RISCV64_PATH 			?= $(TOOLCHAIN_ROOT)/riscv64
+RISCV64_CROSS_COMPILE 		?= $(RISCV64_PATH)/bin/riscv64-unknown-linux-gnu-
+RISCV64_GCC_RELEASE_DATE	?= 2023.07.07
+RISCV64_GCC_VERSION		?= riscv64-glibc-ubuntu-22.04-gcc-nightly-$(RISCV64_GCC_RELEASE_DATE)-nightly
+SRC_RISCV64_GCC			?= https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/$(RISCV64_GCC_RELEASE_DATE)/$(RISCV64_GCC_VERSION).tar.gz
+
+.PHONY: toolchains
+toolchains: riscv64
+
+.PHONY: riscv64
+riscv64:
+	$(call dltc,$(RISCV64_PATH),$(SRC_RISCV64_GCC),$(RISCV64_GCC_VERSION))
+
+endif
 
 else ifeq ($(UNAME_M),aarch64)
 


### PR DESCRIPTION
This PR adds "TARGET_ARCH" variable to download either ARM or RISC-V toolchains.
If "TARGET_ARCH" is specified as "riscv", the RISC-V 64-bit toolchain will be downloaded from riscv-gnu-toolchain\[1] repository and decompressed to `toolchains/riscv64` folder.

\[1]: https://github.com/riscv-collab/riscv-gnu-toolchain/releases

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
