### PR TITLE
Fix download cross compiler toolchain failed.

### DIFF
--- a/toolchain.mk
+++ b/toolchain.mk
@@ -15,7 +15,7 @@ define dltc
 	@if [ ! -d "$(1)" ]; then \
 		echo "Downloading $(3) ..."; \
 		mkdir -p $(1); \
-		curl --retry 5 -k -s -S -L $(2) -o $(TOOLCHAIN_ROOT)/$(3).tar.xz || \
+		wget --tries=5  $(2) -O $(TOOLCHAIN_ROOT)/$(3).tar.xz || \
 			{ rm -f $(TOOLCHAIN_ROOT)/$(3).tar.xz; cd $(TOOLCHAIN_ROOT) && rmdir $(1); echo Download failed; exit 1; }; \
 		tar xf $(TOOLCHAIN_ROOT)/$(3).tar.xz -C $(1) --strip-components=1 || \
 			{ rm $(TOOLCHAIN_ROOT)/$(3).tar.xz; echo Downloaded file is damaged; \


### PR DESCRIPTION
The previous execution of "make -f toolchain.mk  toolchains" command failed to download the compiler toolchains,and this commit fixed  this error.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
