### PR TITLE
qemu_v8: u-boot: fix load address of kernel and RAM disk

### DIFF
--- a/kconfigs/u-boot_qemu_v8.conf
+++ b/kconfigs/u-boot_qemu_v8.conf
@@ -1,3 +1,3 @@
 CONFIG_SYS_TEXT_BASE=0x60000000
-CONFIG_BOOTCOMMAND="smhload uImage ${kernel_addr_r} && smhload rootfs.cpio.uboot ${ramdisk_addr_r} &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
+CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x42200000 && setenv ramdisk_addr_r 0x45000000 && load hostfs - ${kernel_addr_r} uImage && load hostfs - ${ramdisk_addr_r} rootfs.cpio.uboot &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
 CONFIG_SEMIHOSTING=y

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -86,11 +86,12 @@ KERNEL_IMAGE		?= $(LINUX_PATH)/arch/arm64/boot/Image
 KERNEL_IMAGEGZ		?= $(LINUX_PATH)/arch/arm64/boot/Image.gz
 KERNEL_UIMAGE		?= $(BINARIES_PATH)/uImage
 
-# Load and entry addresses
-KERNEL_ENTRY		?= 0x40400000
-KERNEL_LOADADDR		?= 0x40400000
-ROOTFS_ENTRY		?= 0x44000000
-ROOTFS_LOADADDR		?= 0x44000000
+# Load and entry addresses (u-boot only)
+# If you change this please also change in kconfigs/u-boot_qemu_v8.conf
+KERNEL_ENTRY		?= 0x42200000
+KERNEL_LOADADDR		?= 0x42200000
+ROOTFS_ENTRY		?= 0x45000000
+ROOTFS_LOADADDR		?= 0x45000000
 
 ifeq ($(SPMC_AT_EL),2)
 BL32_DEPS		?= hafnium optee-os


### PR DESCRIPTION
This commit changes the load address of the kernel and of the RAM disk when U-Boot is used (make UBOOT=y). It fixes the following boot error with v2023.07.02:

  ** Reading file would overwrite reserved memory **

- The kernel load address, ${kernel_addr_r}, is moved from 0x40400000 (the default defined in u-boot/board/emulation/qemu-arm/qemu-arm.env) to 0x42200000 because the current kernel size is too big to fit in the available space:
  0x40400000 + 38783552 (current uImage size, ~37 M) = 0x446FCA40
  Output of the U-Boot 'bdinfo':
   => bdinfo
   ...
   lmb_dump_all:
    memory.cnt = 0x1 / max = 0x10
    memory[0]      [0x40000000-0x820fffff], 0x42100000 bytes flags: 0
    reserved.cnt = 0x4 / max = 0x10
    reserved[0]    [0xe100000-0xeffffff], 0x00f00000 bytes flags: 4
    reserved[1]    [0x42000000-0x421fffff], 0x00200000 bytes flags: 4
    reserved[2]    [0x7f99b000-0x820fffff], 0x02765000 bytes flags: 0
    reserved[3]    [0x8099b3e0-0x820fffff], 0x01764c20 bytes flags: 0
  There is indeed an overlap with reserved[1].
- The RAM disk is loaded at 0x44000000 by default (${ramdisk_addr_r}).
With the above change it needs to be moved to a higher address, after
the end of the kernel (0x446FCA40). Let's take some margin and choose
0x45000000.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
