### PR TITLE
QEMU_v8: remove EDK2

### DIFF
--- a/kconfigs/u-boot_qemu_v8.conf
+++ b/kconfigs/u-boot_qemu_v8.conf
@@ -1,3 +1,3 @@
 CONFIG_SYS_TEXT_BASE=0x60000000
-CONFIG_BOOTCOMMAND="smhload uImage ${kernel_addr_r} && smhload rootfs.cpio.uboot ${ramdisk_addr_r} &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
+CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x42200000 && setenv ramdisk_addr_r 0x45000000 && load hostfs - ${kernel_addr_r} uImage && load hostfs - ${ramdisk_addr_r} rootfs.cpio.uboot &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
 CONFIG_SEMIHOSTING=y

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -86,11 +86,12 @@ KERNEL_IMAGE		?= $(LINUX_PATH)/arch/arm64/boot/Image
 KERNEL_IMAGEGZ		?= $(LINUX_PATH)/arch/arm64/boot/Image.gz
 KERNEL_UIMAGE		?= $(BINARIES_PATH)/uImage
 
-# Load and entry addresses
-KERNEL_ENTRY		?= 0x40400000
-KERNEL_LOADADDR		?= 0x40400000
-ROOTFS_ENTRY		?= 0x44000000
-ROOTFS_LOADADDR		?= 0x44000000
+# Load and entry addresses (u-boot only)
+# If you change this please also change in kconfigs/u-boot_qemu_v8.conf
+KERNEL_ENTRY		?= 0x42200000
+KERNEL_LOADADDR		?= 0x42200000
+ROOTFS_ENTRY		?= 0x45000000
+ROOTFS_LOADADDR		?= 0x45000000
 
 ifeq ($(SPMC_AT_EL),2)
 BL32_DEPS		?= hafnium optee-os


### PR DESCRIPTION
~~Please ignore the first commit ("qemu_v8: u-boot: fix load address of kernel and RAM disk") which is submitted as https://github.com/OP-TEE/build/pull/670 and review the second one only ("qemu_v8: remove EDK2").~~ Edit: let's review both commits here.