### PR TITLE
qemu_v8: add uImage target

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -394,6 +394,9 @@ $(KERNEL_UIMAGE): u-boot linux | $(BINARIES_PATH)
 				-n "Linux kernel" \
 				-d $(BINARIES_PATH)/linux.bin $(KERNEL_UIMAGE)
 
+.PHONY: uImage
+uImage: $(KERNEL_UIMAGE)
+
 $(ROOTFS_UGZ): u-boot buildroot | $(BINARIES_PATH)
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)
 	$(MKIMAGE_PATH)/mkimage -A arm64 \


### PR DESCRIPTION
"make linux" builds the kernel but is not sufficient to prepare all files for "make run-only". On the other hand, "make run" does a bit too many things to be used comfortably when working on the kernel.

Therefore, add target uImage which generates the kernel image ready to be used by U-Boot. With that, kernel development and testing can be done with the following sequence:

 1. make
 2. Edit kernel sources
 3. make -j$(nproc) uImage
 4. make run-only
 5. Go to 2 -- repeat as needed

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
