### PR TITLE
qemu_v8: use QEMU_VIRT in check target

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -108,7 +108,7 @@ if {[string first "aarch64" $::env(QEMU)] != -1} {
 	if {$::env(XEN_BOOT) == "y"} {
 		spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,acpi=off,secure=on,mte=$::env(QEMU_MTE),gic-version=$::env(QEMU_GIC),virtualization=true -cpu $::env(QEMU_CPU) -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2" -drive if=none,file=xen.ext4,format=raw,id=hd1 -device virtio-blk-device,drive=hd1 -fsdev local,id=fsdev0,path=../..,security_model=none -device virtio-9p-device,fsdev=fsdev0,mount_tag=host
 	} else {
-		spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,acpi=off,secure=on,mte=$::env(QEMU_MTE),gic-version=$::env(QEMU_GIC) -cpu $::env(QEMU_CPU) -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2"
+		spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,acpi=off,secure=on,mte=$::env(QEMU_MTE),gic-version=$::env(QEMU_GIC),virtualization=$::env(QEMU_VIRT) -cpu $::env(QEMU_CPU) -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2"
 	}
 } else {
 	spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable=on,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -508,6 +508,7 @@ check: $(CHECK_DEPS)
 		export QEMU_GIC=$(QEMU_GIC_VERSION) && \
 		export QEMU_MEM=$(QEMU_MEM) && \
 		export QEMU_CPU=$(QEMU_CPU) && \
+		export QEMU_VIRT=$(QEMU_VIRT) && \
 		export XEN_BOOT=$(XEN_BOOT) && \
 		expect $(ROOT)/build/qemu-check.exp -- $(check-args) || \
 		(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \


### PR DESCRIPTION
Export QEMU_VIRT in the check target and update the expect script to use QEMU_VIRT when adding the "virtualization" to QEMU. This enables the check target with Hafnium, that is, SPMC_AT_EL=2.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
