### PR TITLE
qemu_v8: add support to run secondary OP-TEE

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -225,6 +225,7 @@ endif
 	rm -f $(BINARIES_PATH)/bl32_extra2.bin
 	rm -f $(BINARIES_PATH)/tos_fw_config.dtb
 	rm -f $(BINARIES_PATH)/op-tee.pkg
+	rm -f $(BINARIES_PATH)/sec-op-tee.pkg
 ifeq ($(SPMC_AT_EL),1)
 	ln -sf $(TF_A_OUT)/fdts/spmc_el1_manifest.dtb \
 		$(BINARIES_PATH)/tos_fw_config.dtb
@@ -238,6 +239,7 @@ else ifeq ($(SPMC_AT_EL),2)
 		$(BINARIES_PATH)/tb_fw_config.dtb
 	ln -sf $(HAFNIUM_BIN) $(BINARIES_PATH)/bl32.bin
 	ln -sf $(TF_A_OUT)/op-tee.pkg $(BINARIES_PATH)/op-tee.pkg
+	ln -sf $(TF_A_OUT)/sec-op-tee.pkg $(BINARIES_PATH)/sec-op-tee.pkg
 else ifeq ($(SPMC_AT_EL),3)
 	ln -sf $(TF_A_OUT)/fdts/spmc_el3_manifest.dtb \
 		$(BINARIES_PATH)/tos_fw_config.dtb

--- a/qemu_v8/secondary_optee_sp_manifest.dts
+++ b/qemu_v8/secondary_optee_sp_manifest.dts
@@ -15,15 +15,15 @@
 	compatible = "arm,ffa-manifest-1.0";
 
 	/* Properties */
-	description = "op-tee";
+	description = "sec-op-tee";
 	ffa-version = <0x00010000>; /* 31:16 - Major, 15:0 - Minor */
-	uuid = <0xe0786148 0xe311f8e7 0x02005ebc 0x1bc5d5a5>;
+	uuid = <0xe4b5f42f 0xed112faf 0x3351d7b9 0xe9cc99fc>;
 	id = <1>;
 	execution-ctx-count = <8>;
 	exception-level = <2>; /* S-EL1 */
 	execution-state = <0>; /* AARCH64 */
-	load-address = <0xe300000>;
-	mem-size = <0x700000>;	/* OP-TEE specific extension */
+	load-address = <0xea00000>;
+	mem-size = <0x600000>;	/* OP-TEE specific extension */
 	entrypoint-offset = <0x4000>;
 	xlat-granule = <0>; /* 4KiB */
 	boot-order = <0>;

--- a/qemu_v8/sp_layout.json
+++ b/qemu_v8/sp_layout.json
@@ -2,5 +2,10 @@
 	"op-tee" : {
 		"image": "../../optee_os/out/arm/core/tee-pager_v2.bin",
 		"pm": "optee_sp_manifest.dts"
+	},
+
+	"sec-op-tee" : {
+		"image": "../../optee_os/out/arm/core/tee-pager_v2.bin",
+		"pm": "secondary_optee_sp_manifest.dts"
 	}
 }

--- a/qemu_v8/spmc_el2_manifest.dts
+++ b/qemu_v8/spmc_el2_manifest.dts
@@ -30,7 +30,15 @@
 			load_address = <0xe300000>;
 			debug_name = "op-tee";
 			vcpu_count = <4>;
-			mem_size = <0xd00000>;
+			mem_size = <0x700000>;
+		};
+
+		vm2 {
+			is_ffa_partition;
+			load_address = <0xea00000>;
+			debug_name = "sec-op-tee";
+			vcpu_count = <4>;
+			mem_size = <0x600000>;
 		};
 	};
 

--- a/qemu_v8/tb_fw_config.dts
+++ b/qemu_v8/tb_fw_config.dts
@@ -14,5 +14,10 @@
 		       uuid = "486178e0-e7f8-11e3-bc5e-0002a5d5c51b";
 		       load-address = <0xe300000>;
 		};
+
+		sec-op-tee {
+		       uuid = "2ff4b5e4-af2f-11ed-b9d7-5133fc99cce9";
+		       load-address = <0xea00000>;
+		};
 	};
 };


### PR DESCRIPTION
Add support to run a secondary OP-TEE at S-EL1 for SPMC_AT_EL=2 option, where Hafnium is loaded at S-EL2.