### PR TITLE
Adding in the PetaLinux patch that enables XilNvm and XilPuf

### DIFF
--- a/versal/bootImage-versal-vck190.bif
+++ b/versal/bootImage-versal-vck190.bif
@@ -2,7 +2,7 @@ the_ROM_image:
 {
 	image {
 	      { type=bootimage, file=../versal-vck190-bsp/project-spec/hw-description/vpl_gen_fixed.pdi }
-	      { type=bootloader, file=../versal-vck190-bsp/pre-built/linux/images/plm.elf }
+	      { type=bootloader, file=../versal-vck190-bsp/images/linux/plm.elf }
 	      { core=psm, file=../versal-vck190-bsp/pre-built/linux/images/psmfw.elf }
 	}
 

--- a/versal/plm-firmware_%.bbappend
+++ b/versal/plm-firmware_%.bbappend
@@ -1,0 +1,10 @@
+# Add the required security libraries for Versal OP-TEE as only XilSecure is
+# enabled by default
+
+YAML_BSP_CONFIG += "plm_nvm_en plm_puf_en"
+
+# Enable the XilNvm library to allow PLM access to eFUSEs and BBRAM
+YAML_BSP_CONFIG[plm_nvm_en] = "set,true"
+
+# Enable the XilPuf library to allow PLM access to PUF functionality
+YAML_BSP_CONFIG[plm_puf_en] = "set,true"


### PR DESCRIPTION
Adding in the PetaLinux patch that enables XilNvm and XilPuf, which is required by the Versal OP-TEE port.
