### PR TITLE
qemu_v8: xen: re-use Dom0 root FS for DomU

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -355,31 +355,6 @@ buildroot-clean:
 buildroot-cleaner:
 	@rm -rf $(ROOT)/out-br
 
-.PHONY: buildroot-domu
-buildroot-domu: optee-os
-	@mkdir -p ../out-br-domu
-	@rm -f ../out-br-domu/build/optee_*/.stamp_*
-	@rm -f ../out-br-domu/extra.conf
-	@$(call append-br2-vars,../out-br-domu/extra.conf)
-	@(cd .. && $(PYTHON3) build/br-ext/scripts/make_def_config.py \
-		--br buildroot --out out-br-domu --br-ext build/br-ext \
-		--top-dir "$(ROOT)" \
-		--br-defconfig build/br-ext/configs/optee_$(BUILDROOT_ARCH) \
-		--br-defconfig build/br-ext/configs/optee_generic \
-		--br-defconfig build/br-ext/configs/$(BUILDROOT_TOOLCHAIN) \
-		$(DEFCONFIG_GDBSERVER) \
-		--br-defconfig out-br-domu/extra.conf \
-		--make-cmd $(MAKE))
-	@$(MAKE) $(br-make-flags) -C ../out-br-domu all
-
-.PHONY: buildroot-domu-clean
-buildroot-domu-clean:
-	@test ! -d $(ROOT)/out-br-domu || $(MAKE) -C $(ROOT)/out-br-domu clean
-
-.PHONY: buildroot-domu-cleaner
-buildroot-domu-cleaner:
-	@rm -rf $(ROOT)/out-br-domu
-
 ################################################################################
 # Linux
 ################################################################################

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -115,8 +115,7 @@ TARGET_DEPS		+= $(KERNEL_UIMAGE) $(ROOTFS_UGZ)
 TARGET_CLEAN		+= u-boot-clean
 
 ifeq ($(XEN_BOOT),y)
-TARGET_DEPS		+= xen-create-image buildroot-domu
-TARGET_CLEAN		+= buildroot-domu-clean
+TARGET_DEPS		+= xen-create-image
 endif
 
 all: $(TARGET_DEPS)
@@ -441,7 +440,7 @@ run: all
 
 ifeq ($(XEN_BOOT),y)
 QEMU_CPU	?= cortex-a57
-QEMU_MEM 	?= 2048
+QEMU_MEM 	?= 3072
 QEMU_SMP	?= 4
 QEMU_VIRT	= true
 QEMU_XEN	?= -drive if=none,file=$(XEN_EXT4),format=raw,id=hd1 \

--- a/qemu_v8/xen/guest.cfg
+++ b/qemu_v8/xen/guest.cfg
@@ -1,7 +1,7 @@
 kernel="/mnt/host/linux/arch/arm64/boot/Image"
-memory=160
+memory=1024
 vcpus=1
 command="console=hvc0 earlycon=xenboot"
-ramdisk = "/mnt/host/out-br-domu/images/rootfs.cpio.gz"
+ramdisk = "/mnt/host/out-br/images/rootfs.cpio.gz"
 name="domu"
 tee="optee"


### PR DESCRIPTION
Do not build a specific root FS for DomU. Instead, re-use the one that is built for Dom0. While this is certainly not a typical real-world configuration, it helps reduce both build time and disk space which is beneficial in many ways, especially for CI.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
