### PR TITLE
make: change from localhost to 127.0.0.1

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -166,7 +166,7 @@ run-only:
 	$(call wait-for-ports,54320,54321)
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/arm-softmmu/qemu-system-arm \
 		-nographic \
-		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-serial tcp:127.0.0.1:54320 -serial tcp:127.0.0.1:54321 \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on -cpu cortex-a15 \
 		-d unimp -semihosting-config enable=on,target=native \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -479,7 +479,7 @@ run-only:
 	$(call wait-for-ports,54320,54321)
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 \
 		-nographic \
-		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+		-serial tcp:127.0.0.1:54320 -serial tcp:127.0.0.1:54321 \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,acpi=off,secure=on,mte=$(QEMU_MTE),gic-version=$(QEMU_GIC_VERSION),virtualization=$(QEMU_VIRT) \
 		-cpu $(QEMU_CPU) \


### PR DESCRIPTION
Depending on how to you connect to internet, the tcp.localhost might not always work. You can eventually end up with the following error message:

(qemu) qemu-system-aarch64: -serial tcp:localhost:54320: Failed to connect to 'localhost:54320': Connecti on refused
qemu-system-aarch64: -serial tcp:localhost:54320: could not connect serial device to character backend 't cp:localhost:54320'

Therefore it's better to instead use 127.0.0.1 when connecting to the serial consoles.

FYI, this just happened to me when being at the osfc.io conf. I first couldn't figure out why the "make-run" didn't work. Then I tried disable my WiFi connection and things worked as expect. But to avoid this, as said in the commit message, I think it's better to use 127.0.0.1 instead.