### PR TITLE
fvp, spmc: add missing manifest entry

### DIFF
--- a/fvp/spmc_manifest.dts
+++ b/fvp/spmc_manifest.dts
@@ -30,6 +30,7 @@
 		compatible = "arm,tpm_event_log";
 		tpm_event_log_addr = <0x0 0x0>;
 		tpm_event_log_size = <0x0>;
+		tpm_event_log_max_size = <0x0>;
 	};
 #endif
 


### PR DESCRIPTION
TF-A v2.9 introduced a new mandatory property called "tpm_event_log_max_size" to the "tb_fw_config" DTB under the "tpm_evet_log" node. Add this property to the SPMC manifest file for v2.9 compatibility.

See: https://trustedfirmware-a.readthedocs.io/en/latest/components/measured_boot/event_log.html#dynamic-configuration-for-event-log

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
