### PR TITLE
qemu_v8: add scmi server option

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -421,11 +421,11 @@ QEMU_EXTRA_ARGS +=\
 
 ifeq ($(QEMU_VIRTFS_ENABLE),y)
 QEMU_CONFIGURE_PARAMS_COMMON +=  --enable-virtfs
-QEMU_EXTRA_ARGS +=\
+QEMU_RUN_ARGS_COMMON +=\
 	-fsdev local,id=fsdev0,path=$(QEMU_VIRTFS_HOST_DIR),security_model=none \
 	-device virtio-9p-device,fsdev=fsdev0,mount_tag=host
 ifeq ($(QEMU_PSS_ENABLE),y)
-QEMU_EXTRA_ARGS +=\
+QEMU_RUN_ARGS_COMMON +=\
 	  -fsdev local,id=fsdev1,path=$(QEMU_PSS_HOST_DIR),security_model=mapped-xattr \
 	  -device virtio-9p-device,fsdev=fsdev1,mount_tag=secure
 endif

--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -109,11 +109,7 @@ open "serial1.log" "w+"
 spawn -open [open "|tail -f serial1.log"]
 set teecore $spawn_id
 if {[string first "aarch64" $::env(QEMU)] != -1} {
-	if {$::env(XEN_BOOT) == "y"} {
-		spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,acpi=off,secure=on,mte=$::env(QEMU_MTE),gic-version=$::env(QEMU_GIC),virtualization=true -cpu $::env(QEMU_CPU) -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2" -drive if=none,file=xen.ext4,format=raw,id=hd1 -device virtio-blk-device,drive=hd1 -fsdev local,id=fsdev0,path=../..,security_model=none -device virtio-9p-device,fsdev=fsdev0,mount_tag=host
-	} else {
-		spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,acpi=off,secure=on,mte=$::env(QEMU_MTE),gic-version=$::env(QEMU_GIC),virtualization=$::env(QEMU_VIRT) -cpu $::env(QEMU_CPU) -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2"
-	}
+	spawn sh -c "$::env(QEMU) $::env(QEMU_CHECK_ARGS)"
 } else {
 	spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable=on,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
 }

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -259,10 +259,14 @@ $(QEMU_BUILD)/config-host.mak:
 	cd $(QEMU_PATH); ./configure --target-list=aarch64-softmmu --enable-slirp\
 			$(QEMU_CONFIGURE_PARAMS_COMMON)
 
-qemu: $(QEMU_BUILD)/config-host.mak
+qemu: $(QEMU_BUILD)/.stamp_qemu
+
+$(QEMU_BUILD)/.stamp_qemu: $(QEMU_BUILD)/config-host.mak
 	$(MAKE) -C $(QEMU_PATH)
+	touch $@
 
 qemu-clean:
+	rm -f $(QEMU_BUILD)/.stamp_qemu
 	$(MAKE) -C $(QEMU_PATH) distclean
 
 ################################################################################

--- a/qemu_v8/qemu-v8-scmi-overlay.dtso
+++ b/qemu_v8/qemu-v8-scmi-overlay.dtso
@@ -1,0 +1,50 @@
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	cpus {
+		cpu@0 {
+			clocks = <&scmi_dvfs 0>;
+		};
+
+		cpu@1 {
+			clocks = <&scmi_dvfs 0>;
+		};
+	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+
+		scmi: scmi0 {
+			compatible = "linaro,scmi-optee";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			linaro,optee-channel-id = <0x01>;
+
+			scmi_devpd: protocol@11 {
+				reg = <0x11>;
+				#power-domain-cells = <1>;
+			};
+
+			scmi_clk0: protocol@14 {
+				reg = <0x14>;
+				#clock-cells = <1>;
+			};
+
+			scmi_sensors0: protocol@15 {
+				reg = <0x15>;
+				#thermal-sensor-cells = <1>;
+			};
+
+			scmi_dvfs: protocol@13 {
+				reg = <0x13>;
+				#clock-cells = <1>;
+				linaro,optee-channel-id = <0x02>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add a dts file with SCMI server node:
  - Connect SCMI server to cpufreq
  - Populate power domain
  - Populate performance domain
  - Populate clock
  - Populate sensor

The dts file has been generated with qemu dumpdtb option

Add *-with-scmi commands to boot with the scmi server
  - run-with-scmi
  - run-only-with-scmi

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
