### PR TITLE
stm32mp1: update Linux DTS files path

### DIFF
--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -162,12 +162,12 @@ linux-defconfig: $(LINUX_PATH)/.config
 
 LINUX_COMMON_FLAGS += ARCH=arm uImage LOADADDR=0xc2000000 \
 		      CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
-		      $(STM32MP1_DTS_BASENAME).dtb \
+		      st/$(STM32MP1_DTS_BASENAME).dtb \
 		      PATH=$$PATH:$(U_BOOT_PATH)/tools
 
 linux: linux-common
 	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/$(LINUX_KERNEL_BIN))
-	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/dts/$(LINUX_DTB_BIN))
+	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/dts/st/$(LINUX_DTB_BIN))
 
 linux-defconfig-clean: linux-defconfig-clean-common
 

--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -56,7 +56,6 @@ OPTEE_PAGEABLE_BIN  	:= tee-pageable_v2.bin
 U_BOOT_BIN		:= u-boot.bin
 U_BOOT_DTB		:= u-boot.dtb
 LINUX_KERNEL_BIN 	:= uImage
-LINUX_DTB_BIN		:= $(STM32MP1_DTS_BASENAME).dtb
 
 ################################################################################
 # Paths to git projects and various binaries
@@ -167,7 +166,7 @@ LINUX_COMMON_FLAGS += ARCH=arm uImage LOADADDR=0xc2000000 \
 
 linux: linux-common
 	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/$(LINUX_KERNEL_BIN))
-	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/dts/st/$(LINUX_DTB_BIN))
+	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/dts/st/$(STM32MP1_DTS_BASENAME).dtb)
 
 linux-defconfig-clean: linux-defconfig-clean-common
 
@@ -230,7 +229,7 @@ copy_images_to_br: tfa optee-os u-boot linux
 	$(call install_in_br_images,$(U_BOOT_BIN))
 	$(call install_in_br_images,$(U_BOOT_DTB))
 	$(call install_in_br_images,$(LINUX_KERNEL_BIN))
-	$(call install_in_br_images,$(LINUX_DTB_BIN))
+	$(call install_in_br_images,$(STM32MP1_DTS_BASENAME).dtb)
 	$(call install_in_br_images,$(OPTEE_HEADER_BIN))
 	$(call install_in_br_images,$(OPTEE_PAGER_BIN))
 	$(call install_in_br_images,$(OPTEE_PAGEABLE_BIN))


### PR DESCRIPTION
Updates path of the Linux kernel in-tree DT files that have moved to vendor sub-directories since kernel v6.5.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=724ba6751532055db75992fc6ae21c3e322e94a7

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
