### PR TITLE
qemu: make local ports in use configurable

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -105,6 +105,10 @@ QEMU_VIRTFS_MOUNTPOINT	?= /mnt/host
 
 # End of QEMU shared folder settings
 
+# The ports used for the consoles that are spawned when running QEMU.
+QEMU_NW_PORT ?= 54320
+QEMU_SW_PORT ?= 54321
+
 ################################################################################
 # Mandatory for autotools (for specifying --host)
 ################################################################################

--- a/qemu.mk
+++ b/qemu.mk
@@ -161,12 +161,12 @@ run-only:
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(call check-terminal)
 	$(call run-help)
-	$(call launch-terminal,54320,"Normal World")
-	$(call launch-terminal,54321,"Secure World")
-	$(call wait-for-ports,54320,54321)
+	$(call launch-terminal,$(QEMU_NW_PORT),"Normal World")
+	$(call launch-terminal,$(QEMU_SW_PORT),"Secure World")
+	$(call wait-for-ports,$(QEMU_NW_PORT),$(QEMU_SW_PORT))
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/arm-softmmu/qemu-system-arm \
 		-nographic \
-		-serial tcp:127.0.0.1:54320 -serial tcp:127.0.0.1:54321 \
+		-serial tcp:127.0.0.1:$(QEMU_NW_PORT) -serial tcp:127.0.0.1:$(QEMU_SW_PORT) \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,secure=on -cpu cortex-a15 \
 		-d unimp -semihosting-config enable=on,target=native \

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -475,12 +475,12 @@ run-only:
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
 	$(call check-terminal)
 	$(call run-help)
-	$(call launch-terminal,54320,"Normal World")
-	$(call launch-terminal,54321,"Secure World")
-	$(call wait-for-ports,54320,54321)
+	$(call launch-terminal,$(QEMU_NW_PORT),"Normal World")
+	$(call launch-terminal,$(QEMU_SW_PORT),"Secure World")
+	$(call wait-for-ports,$(QEMU_NW_PORT),$(QEMU_SW_PORT))
 	cd $(BINARIES_PATH) && $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 \
 		-nographic \
-		-serial tcp:127.0.0.1:54320 -serial tcp:127.0.0.1:54321 \
+		-serial tcp:127.0.0.1:$(QEMU_NW_PORT) -serial tcp:127.0.0.1:$(QEMU_SW_PORT) \
 		-smp $(QEMU_SMP) \
 		-s -S -machine virt,acpi=off,secure=on,mte=$(QEMU_MTE),gic-version=$(QEMU_GIC_VERSION),virtualization=$(QEMU_VIRT) \
 		-cpu $(QEMU_CPU) \


### PR DESCRIPTION
Make it possible to set the local ports used for the non-secure (QEMU_NW_PORT) and secure (QEMU_SW_PORT) terminal when running QEMU.

When you need to run multiple QEMU/OP-TEE instances (debugging, multi-user etc.) on the same physical (non-containerized environment) computer, this is useful because you can avoid port collisions (port already in use message) by simply setting non-clashing port numbers when running make and thereby also avoid making changes directly to the makefile.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
