### PR TITLE
stm32mp1: enlarge MP15 pager page pool + test config for RPMB_FS

### DIFF
--- a/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-STM32MP157C-EV1-rpmb/etc/init.d/S30optee
+++ b/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-STM32MP157C-EV1-rpmb/etc/init.d/S30optee
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+DAEMON="tee-supplicant"
+DAEMON_PATH="/usr/sbin"
+DAEMON_ARGS="-d /dev/teepriv0"
+PIDFILE="/var/run/$DAEMON.pid"
+
+start() {
+	# tee-supplicant and the client applications need not run as
+	# root provided that the TEE devices and the data store have
+	# proper permissions
+	printf 'Set permissions on %s: ' "/dev/tee*"
+	chown root:tee /dev/teepriv0 && chmod 0660 /dev/teepriv0 && \
+		chown root:teeclnt /dev/tee0 && chmod 0660 /dev/tee0
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+		return "$status"
+	fi
+	printf 'Create/set permissions on %s: ' "/data/tee"
+	mkdir -p /data/tee && chown -R tee:tee /data/tee && chmod 0770 /data/tee
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+		return "$status"
+	fi
+	printf 'Starting %s: ' "$DAEMON"
+	start-stop-daemon -S -q -p "$PIDFILE" -c root -x "$DAEMON_PATH/$DAEMON" \
+		-- $DAEMON_ARGS
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+stop() {
+	printf 'Stopping %s: ' "$DAEMON"
+	start-stop-daemon -K -q -p "$PIDFILE"
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+restart() {
+	stop
+	sleep 1
+	start
+}
+
+case "$1" in
+        start|stop|restart)
+		"$1";;
+	reload)
+		# Restart, since there is no true "reload" feature (does not
+		# reconfigure/restart on SIGHUP, just closes all open files).
+		restart;;
+        *)
+                echo "Usage: $0 {start|stop|restart|reload}"
+                exit 1
+esac

--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -36,6 +36,7 @@ BREXT_FLAVOR		= STM32MP157C-EV1
 STM32MP1_DTS_BASENAME	= stm32mp157c-ev1
 STM32MP1_DTS_LINUX 	?= $(STM32MP1_DTS_BASENAME)-scmi
 STM32MP1_DTS_U_BOOT 	?= $(STM32MP1_DTS_BASENAME)-scmi
+CFG_RPMB_FS_DEV_ID	= 1
 else ifeq ($(PLATFORM),stm32mp1-157C_ED1)
 BREXT_FLAVOR		= STM32MP157C-ED1
 STM32MP1_DTS_BASENAME	= stm32mp157c-ed1
@@ -52,6 +53,11 @@ endif
 STM32MP1_DTS_LINUX ?= $(STM32MP1_DTS_BASENAME)
 STM32MP1_DTS_U_BOOT ?= $(STM32MP1_DTS_BASENAME)
 STM32MP1_DEFCONFIG_U_BOOT ?= stm32mp15_defconfig
+
+# When enabled WITH_RPMB_TEST enables RPMB secure storage test configuration,
+# using OP-TEE RPMB test key (CFG_RPMB_TESTKEY=y). This configuration switch
+# is intended to platforms with an eMMC device.
+WITH_RPMB_TEST ?= n
 
 ################################################################################
 # Binary images names
@@ -94,6 +100,18 @@ include toolchain.mk
 ################################################################################
 # OP-TEE OS
 ################################################################################
+ifeq ($(WITH_RPMB_TEST),y)
+CFG_RPMB_FS_DEV_ID ?= 1
+OPTEE_OS_COMMON_FLAGS += \
+		CFG_RPMB_FS_DEV_ID=$(CFG_RPMB_FS_DEV_ID) \
+		CFG_RPMB_FS=y \
+		CFG_RPMB_TESTKEY=y \
+		CFG_REE_FS_ALLOW_RESET=y
+$(info -------------------------------------------------------------------------------------)
+$(info "WARNING: building with RPMB support for test purpose")
+$(info "         CFG_RPMB_FS_DEV_ID=$(CFG_RPMB_FS_DEV_ID) CFG_RPMB_FS=y, CFG_RPMB_TESTKEY=y and CFG_REE_FS_ALLOW_RESET=y")
+$(info -------------------------------------------------------------------------------------)
+endif # WITH_RPMB_TEST
 
 # Provide scp-firmware source tree path in case CFG_SCMI_SERVER is enabled
 OPTEE_OS_COMMON_FLAGS += CFG_SCP_FIRMWARE=$(SCPFW_PATH)
@@ -203,6 +221,13 @@ BREXT_BOOTFS_OVERLAY=$(BREXT_BOARD_PATH)/overlay-$(BREXT_FLAVOR)
 BR2_PACKAGE_HOST_GENIMAGE=y
 BR2_ROOTFS_POST_SCRIPT_ARGS="$(BREXT_GENIMAGE_CONFIG) $(BINARIES_PATH) $(BREXT_BOOTFS_OVERLAY)"
 BR2_ROOTFS_POST_IMAGE_SCRIPT=$(BREXT_BOARD_PATH)/post-image.sh
+
+ifeq ($(WITH_RPMB_TEST),y)
+# Use S30optee init.d script that runs tee-supplicant with as root
+BR2_ROOTFS_OVERLAY=$(BREXT_BOARD_PATH)/overlay-$(BREXT_FLAVOR)-rpmb
+# Disable RPMB emulation in tee-supplicant
+BR2_PACKAGE_OPTEE_CLIENT_EXT_RPMB_EMU=n
+endif # WITH_RPMB_TEST
 
 # TF-A, Linux kernel, U-Boot and OP-TEE OS/Client/... are not built from their
 # related Buildroot native package.

--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -18,6 +18,7 @@ BREXT_FLAVOR		= STM32MP157A-DK1
 STM32MP1_DTS_BASENAME	= stm32mp157a-dk1
 STM32MP1_DTS_LINUX 	?= $(STM32MP1_DTS_BASENAME)-scmi
 STM32MP1_DTS_U_BOOT 	?= $(STM32MP1_DTS_BASENAME)-scmi
+WITH_SRAM1_PAGER_POOL	?= y
 else ifeq ($(PLATFORM),stm32mp1-157A_DHCOR_AVENGER96)
 BREXT_FLAVOR		= STM32MP157A-DHCOR-AVENGER96
 STM32MP1_DTS_BASENAME	= stm32mp157a-dhcor-avenger96
@@ -31,17 +32,20 @@ BREXT_FLAVOR		= STM32MP157C-DK2
 STM32MP1_DTS_BASENAME	= stm32mp157c-dk2
 STM32MP1_DTS_LINUX 	?= $(STM32MP1_DTS_BASENAME)-scmi
 STM32MP1_DTS_U_BOOT 	?= $(STM32MP1_DTS_BASENAME)-scmi
+WITH_SRAM1_PAGER_POOL	?= y
 else ifeq ($(PLATFORM),stm32mp1-157C_EV1)
 BREXT_FLAVOR		= STM32MP157C-EV1
 STM32MP1_DTS_BASENAME	= stm32mp157c-ev1
 STM32MP1_DTS_LINUX 	?= $(STM32MP1_DTS_BASENAME)-scmi
 STM32MP1_DTS_U_BOOT 	?= $(STM32MP1_DTS_BASENAME)-scmi
+WITH_SRAM1_PAGER_POOL	?= y
 CFG_RPMB_FS_DEV_ID	= 1
 else ifeq ($(PLATFORM),stm32mp1-157C_ED1)
 BREXT_FLAVOR		= STM32MP157C-ED1
 STM32MP1_DTS_BASENAME	= stm32mp157c-ed1
 STM32MP1_DTS_LINUX 	?= $(STM32MP1_DTS_BASENAME)-scmi
 STM32MP1_DTS_U_BOOT 	?= $(STM32MP1_DTS_BASENAME)-scmi
+WITH_SRAM1_PAGER_POOL	?= y
 else ifeq ($(PLATFORM),stm32mp1-135F_DK)
 BREXT_FLAVOR		= STM32MP135F-DK
 STM32MP1_DTS_BASENAME	= stm32mp135f-dk
@@ -58,6 +62,11 @@ STM32MP1_DEFCONFIG_U_BOOT ?= stm32mp15_defconfig
 # using OP-TEE RPMB test key (CFG_RPMB_TESTKEY=y). This configuration switch
 # is intended to platforms with an eMMC device.
 WITH_RPMB_TEST ?= n
+
+# When enabled WITH_SRAM1_PAGER_POOL makes OP-TEE pager core to use secure
+# SYSRAM and SRAM1. This switch concerns STM32MP15 based platforms only.
+# When enabled, CFG_TEE_CORE_DEBUG is also default enabled.
+WITH_SRAM1_PAGER_POOL ?= n
 
 ################################################################################
 # Binary images names
@@ -112,6 +121,13 @@ $(info "WARNING: building with RPMB support for test purpose")
 $(info "         CFG_RPMB_FS_DEV_ID=$(CFG_RPMB_FS_DEV_ID) CFG_RPMB_FS=y, CFG_RPMB_TESTKEY=y and CFG_REE_FS_ALLOW_RESET=y")
 $(info -------------------------------------------------------------------------------------)
 endif # WITH_RPMB_TEST
+
+ifeq ($(WITH_SRAM1_PAGER_POOL),y)
+CFG_TEE_CORE_DEBUG ?= y
+OPTEE_OS_COMMON_FLAGS += \
+		CFG_TZSRAM_SIZE=0x60000 \
+		CFG_TEE_CORE_DEBUG=$(CFG_TEE_CORE_DEBUG)
+endif # WITH_SRAM1_PAGER_POOL
 
 # Provide scp-firmware source tree path in case CFG_SCMI_SERVER is enabled
 OPTEE_OS_COMMON_FLAGS += CFG_SCP_FIRMWARE=$(SCPFW_PATH)


### PR DESCRIPTION
Add build config switch `WITH_RPMB_TEST=y|n` for stm32mp1 platforms for when RPMB support shall be enabled.
This configuration switch is intended by test purpose.

Add build config switch `WITH_SRAM1_PAGER_POOL=y|n` to assign secure SRAM1 to OP-TEE pager as pager page pool. This relaxes pressure in STM32MP15 pager. The switch is default enabled for ST boards based on STM32MP15 chip.