### PR TITLE
qemu_v8: add uRootfs target

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -412,6 +412,9 @@ $(ROOTFS_UGZ): u-boot buildroot | $(BINARIES_PATH)
 				-n "Root file system" \
 				-d $(ROOTFS_GZ) $(ROOTFS_UGZ)
 
+.PHONY: uRootfs
+uRootfs: $(ROOTFS_UGZ)
+
 ################################################################################
 # XEN
 ################################################################################


### PR DESCRIPTION
"make buildroot" generates rootfs.cpio.gz but it's not sufficient to prepare all files for "make run-only".

Add a target uRootfs to generate the a rootfs image ready to be used by U-Boot.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
