### PR TITLE
qemu: Correct initrd-end in u-boot config fragment

### DIFF
--- a/kconfigs/u-boot_qemu_virt_v7.conf
+++ b/kconfigs/u-boot_qemu_virt_v7.conf
@@ -1,5 +1,5 @@
 CONFIG_SYS_TEXT_BASE=0x60000000
-CONFIG_BOOTCOMMAND="fdt addr ${fdt_addr} && fdt resize 1000 && smhload zImage ${kernel_addr_r} && smhload rootfs.cpio.gz ${ramdisk_addr_r} ramdisk_addr_end &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 && fdt chosen ${ramdisk_addr_r} ${ramdisk_addr_end} && bootz ${kernel_addr_r} - ${fdt_addr}"
+CONFIG_BOOTCOMMAND="fdt addr ${fdt_addr} && fdt resize 1000 && smhload zImage ${kernel_addr_r} && smhload rootfs.cpio.gz ${ramdisk_addr_r} ramdisk_addr_end &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 && setexpr ramdisk_addr_end ${ramdisk_addr_end} + 1 && fdt chosen ${ramdisk_addr_r} ${ramdisk_addr_end} && bootz ${kernel_addr_r} - ${fdt_addr}"
 CONFIG_SEMIHOSTING=y
 CONFIG_ENV_IS_NOWHERE=y
 # CONFIG_ENV_IS_IN_FLASH is not set


### PR DESCRIPTION
smhload set ramdisk_addr_end to the end address of rootfs, but the kernel expect linux,initrd-end
to be the first address after the initrd.
Update the default bootcmd to meet the requirement.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
