### PR TITLE
rpi3: Increase size for root files system

### DIFF
--- a/rpi3.mk
+++ b/rpi3.mk
@@ -33,7 +33,7 @@ BR2_PACKAGE_HOST_GENIMAGE=y
 # directly into a parition on the image.
 BR2_TARGET_ROOTFS_EXT2=y
 BR2_TARGET_ROOTFS_EXT2_4=y
-BR2_TARGET_ROOTFS_EXT2_SIZE="128M"
+BR2_TARGET_ROOTFS_EXT2_SIZE="256M"
 
 ################################################################################
 # Paths to git projects and various binaries


### PR DESCRIPTION
As part of updating the manifest to using a more up-to-date Linux kernel, we need to increase the size of the root file system a bit.

With these settings, there is roughly 50MB free on the filesystem before and after running xtest.

This doesn't really affect what I tested [here](https://github.com/OP-TEE/optee_os/pull/6574#issuecomment-1891769754) for the 4.1.0 release, so I see no harm in merging this before the release. On the other hand no hurry either, so this can wait to after the release as well if that is preferable.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
