### PR TITLE
qemuv8: rust.exp: set timeout to 10 seconds

### DIFF
--- a/rust.exp
+++ b/rust.exp
@@ -4,6 +4,8 @@
 # success, >0 for error.
 #
 
+set timeout 10
+
 info "Test Rust example applications:\n"
 info "Running acipher-rs...\n"
 send -- "acipher-rs 256 teststring\r"


### PR DESCRIPTION
There is no timeout specified in rust.exp. This makes the tests unreliable, because depending on which tests have been run before, the $timeout global variable may have different values. For example, it is set to 900 by qemu-check.exp (the main file), but may be overriden by trusted-keys.exp to 5 seconds. That's not enough in some cases, causing the following error in optee_os CI:

 2024-01-19T11:58:23.5778720Z Running signature_verification-rs...
 2024-01-19T11:58:28.3431817Z !!! Timeout: Test failed

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
