### PR TITLE
toolchain.mk: Add support for Rust toolchain for aarch{32/64}

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -331,7 +331,7 @@ br-make-flags := -j1
 endif
 
 .PHONY: buildroot
-buildroot: optee-os optee-rust
+buildroot: optee-os
 	@mkdir -p ../out-br
 	@rm -f ../out-br/build/optee_*/.stamp_*
 	@rm -f ../out-br/extra.conf
@@ -349,7 +349,7 @@ buildroot: optee-os optee-rust
 		$(DEFCONFIG_FTPM) \
 		--br-defconfig out-br/extra.conf \
 		--make-cmd $(MAKE))
-	@$(MAKE) $(br-make-flags) -C ../out-br all
+	@source $(RUST_TOOLCHAIN_PATH)/.cargo/env && $(MAKE) $(br-make-flags) -C ../out-br all
 
 .PHONY: buildroot-clean
 buildroot-clean:
@@ -550,22 +550,6 @@ optee-os-common:
 .PHONY: optee-os-clean-common
 optee-os-clean-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS) clean
-
-################################################################################
-# OP-TEE Rust
-################################################################################
-.PHONY: optee-rust
-optee-rust: $(OPTEE_RUST_PATH)/.done
-
-$(OPTEE_RUST_PATH)/.done:
-ifeq ($(RUST_ENABLE),y)
-	@(export OPTEE_DIR=$(ROOT) && \
-	  export CARGO_NET_GIT_FETCH_WITH_CLI=true && \
-	  cd $(OPTEE_RUST_PATH) && ./setup.sh && touch .done)
-endif
-
-optee-rust-clean:
-	rm -f $(OPTEE_RUST_PATH)/.done
 
 ################################################################################
 # fTPM Rules

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -57,14 +57,14 @@ AARCH64_GCC_VERSION 		?= arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-g
 SRC_AARCH64_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/$(AARCH64_GCC_VERSION).tar.xz
 
 .PHONY: toolchains
-toolchains: aarch32 aarch64
+toolchains: aarch32-toolchain aarch64-toolchain
 
-.PHONY: aarch32
-aarch32:
+.PHONY: aarch32-toolchain
+aarch32-toolchain:
 	$(call dltc,$(AARCH32_PATH),$(SRC_AARCH32_GCC),$(AARCH32_GCC_VERSION))
 
-.PHONY: aarch64
-aarch64:
+.PHONY: aarch64-toolchain
+aarch64-toolchain:
 	$(call dltc,$(AARCH64_PATH),$(SRC_AARCH64_GCC),$(AARCH64_GCC_VERSION))
 
 CLANG_VER			?= 12.0.0
@@ -91,10 +91,10 @@ RISCV64_GCC_VERSION		?= riscv64-glibc-ubuntu-22.04-gcc-nightly-$(RISCV64_GCC_REL
 SRC_RISCV64_GCC			?= https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/$(RISCV64_GCC_RELEASE_DATE)/$(RISCV64_GCC_VERSION).tar.gz
 
 .PHONY: toolchains
-toolchains: riscv64
+toolchains: riscv64-toolchain
 
-.PHONY: riscv64
-riscv64:
+.PHONY: riscv64-toolchain
+riscv64-toolchain:
 	$(call dltc,$(RISCV64_PATH),$(SRC_RISCV64_GCC),$(RISCV64_GCC_VERSION))
 
 endif
@@ -115,10 +115,10 @@ AARCH64_PATH 			?= $(TOOLCHAIN_ROOT)/aarch64
 AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-
 
 .PHONY: toolchains
-toolchains: aarch32 $(AARCH64_PATH)/.done
+toolchains: aarch32-toolchain $(AARCH64_PATH)/.done
 
-.PHONY: aarch32
-aarch32:
+.PHONY: aarch32-toolchain
+aarch32-toolchain:
 	$(call dltc,$(AARCH32_PATH),$(SRC_AARCH32_GCC),$(AARCH32_GCC_VERSION))
 
 $(AARCH64_PATH)/.done:

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -56,8 +56,10 @@ AARCH64_CROSS_COMPILE 		?= $(AARCH64_PATH)/bin/aarch64-linux-gnu-
 AARCH64_GCC_VERSION 		?= arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-gnu
 SRC_AARCH64_GCC 		?= https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/$(AARCH64_GCC_VERSION).tar.xz
 
+RUST_TOOLCHAIN_PATH 		?= $(TOOLCHAIN_ROOT)/rust
+
 .PHONY: toolchains
-toolchains: aarch32-toolchain aarch64-toolchain
+toolchains: aarch32-toolchain aarch64-toolchain rust-toolchain
 
 .PHONY: aarch32-toolchain
 aarch32-toolchain:
@@ -66,6 +68,24 @@ aarch32-toolchain:
 .PHONY: aarch64-toolchain
 aarch64-toolchain:
 	$(call dltc,$(AARCH64_PATH),$(SRC_AARCH64_GCC),$(AARCH64_GCC_VERSION))
+
+# Download the Rust toolchain
+define dl-rust-toolchain
+	@if [ ! -d "$(1)" ]; then \
+		mkdir -p $(1) && \
+		export RUSTUP_HOME=$(1)/.rustup && \
+		export CARGO_HOME=$(1)/.cargo && \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path && \
+		source "$(1)/.cargo/env" && \
+		rustup target install aarch64-unknown-linux-gnu && \
+		rustup target install arm-unknown-linux-gnueabihf && \
+		rustup default nightly-2023-12-18; \
+	fi
+endef
+
+.PHONY: rust-toolchain
+rust-toolchain:
+	$(call dl-rust-toolchain,$(RUST_TOOLCHAIN_PATH))
 
 CLANG_VER			?= 12.0.0
 CLANG_PATH			?= $(ROOT)/clang-$(CLANG_VER)


### PR DESCRIPTION
Rather than invoking custom setup.sh script provided by OP-TEE Rust SDK, add Rust toolchain installation support as part of toolchain Makefile. This allows to separate OP-TEE specific Rust toolchain installation from default Rust toolchain installation. Now all OP-TEE specific Rust toolchains will be installed under: $(ROOT)/toolchains/rust/.