### PR TITLE
qemu_v8: Disable Rust examples by default

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -30,7 +30,7 @@ QEMU_VIRTFS_AUTOMOUNT = y
 endif
 
 # Option to enable Rust examples
-RUST_ENABLE ?= y
+RUST_ENABLE ?= n
 
 include common.mk
 


### PR DESCRIPTION
There has been random CI build failures reported while building Rust examples. Most of them seems like conflicts with buildroot provided Rust toolchain. So until those are resolved, disable default Rust examples build for now to get the CI passing successfully.