### PR TITLE
common.mk: add linux-menuconfig-common target

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -364,6 +364,10 @@ buildroot-cleaner:
 ################################################################################
 LINUX_COMMON_FLAGS ?= LOCALVERSION= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL)
 
+.PHONY: linux-menuconfig-common
+linux-menuconfig-common: linux-defconfig
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) menuconfig
+
 .PHONY: linux-common
 linux-common: linux-defconfig
 	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) $(LINUX_COMMON_TARGETS)

--- a/common.mk
+++ b/common.mk
@@ -366,7 +366,7 @@ LINUX_COMMON_FLAGS ?= LOCALVERSION= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL)
 
 .PHONY: linux-common
 linux-common: linux-defconfig
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS)
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) $(LINUX_COMMON_TARGETS)
 
 $(LINUX_PATH)/.config: $(LINUX_DEFCONFIG_COMMON_FILES)
 	cd $(LINUX_PATH) && \
@@ -378,15 +378,13 @@ $(LINUX_PATH)/.config: $(LINUX_DEFCONFIG_COMMON_FILES)
 linux-defconfig-clean-common:
 	rm -f $(LINUX_PATH)/.config
 
-# LINUX_CLEAN_COMMON_FLAGS should be defined in specific makefiles (hikey.mk,...)
 .PHONY: linux-clean-common
 linux-clean-common: linux-defconfig-clean
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEAN_COMMON_FLAGS) clean
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) clean
 
-# LINUX_CLEANER_COMMON_FLAGS should be defined in specific makefiles (hikey.mk,...)
 .PHONY: linux-cleaner-common
 linux-cleaner-common: linux-defconfig-clean
-	$(MAKE) -C $(LINUX_PATH) $(LINUX_CLEANER_COMMON_FLAGS) distclean
+	$(MAKE) -C $(LINUX_PATH) $(LINUX_COMMON_FLAGS) distclean
 
 ################################################################################
 # EDK2 / Tianocore

--- a/hikey.mk
+++ b/hikey.mk
@@ -173,7 +173,8 @@ linux-gen_init_cpio: linux-defconfig
 		LOCALVERSION= \
 		gen_init_cpio
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image hisilicon/hi6220-hikey.dtb
+LINUX_COMMON_FLAGS += ARCH=arm64
+LINUX_COMMON_TARGETS += Image hisilicon/hi6220-hikey.dtb
 
 .PHONY: linux
 linux: linux-common

--- a/hikey960.mk
+++ b/hikey960.mk
@@ -169,7 +169,8 @@ linux-gen_init_cpio: linux-defconfig
 		LOCALVERSION= \
 		gen_init_cpio
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image hisilicon/hi3660-hikey960.dtb
+LINUX_COMMON_FLAGS += ARCH=arm64
+LINUX_COMMON_TARGETS += Image hisilicon/hi3660-hikey960.dtb
 
 .PHONY: linux
 linux: linux-common

--- a/qemu.mk
+++ b/qemu.mk
@@ -124,7 +124,8 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm zImage
+LINUX_COMMON_FLAGS += ARCH=arm
+LINUX_COMMON_TARGETS += zImage
 
 linux: linux-common
 	mkdir -p $(BINARIES_PATH)

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -308,7 +308,8 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image scripts_gdb
+LINUX_COMMON_FLAGS += ARCH=arm64
+LINUX_COMMON_TARGETS += Image scripts_gdb
 
 linux: linux-common
 	mkdir -p $(BINARIES_PATH)

--- a/rockpi4.mk
+++ b/rockpi4.mk
@@ -124,7 +124,8 @@ LINUX_DEFCONFIG_COMMON_FILES ?= $(LINUX_PATH)/arch/arm64/configs/defconfig \
 .PHONY: linux-defconfig
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm64 Image rockchip/rk3399-rock-pi-4b.dtb \
+LINUX_COMMON_FLAGS += ARCH=arm64
+LINUX_COMMON_TARGETS += Image rockchip/rk3399-rock-pi-4b.dtb \
 			$(if $(filter y,$(LINUX_MODULES)),modules)
 
 .PHONY: linux

--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -208,10 +208,10 @@ LINUX_DEFCONFIG_COMMON_FILES := \
 
 linux-defconfig: $(LINUX_PATH)/.config
 
-LINUX_COMMON_FLAGS += ARCH=arm uImage LOADADDR=0xc2000000 \
+LINUX_COMMON_FLAGS += ARCH=arm LOADADDR=0xc2000000 \
 		      CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
-		      st/$(STM32MP1_DTS_LINUX).dtb \
 		      PATH=$$PATH:$(U_BOOT_PATH)/tools
+LINUX_COMMON_TARGETS += uImage st/$(STM32MP1_DTS_LINUX).dtb
 
 linux: linux-common
 	@$(call install_in_binaries,$(LINUX_PATH)/arch/arm/boot/$(LINUX_KERNEL_BIN))


### PR DESCRIPTION
Adds a linux-menuconfig-common target to run "make menuconfig" with environment and flags matching the configured linux kernel.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
