### PR TITLE
common: target optee-os-devkit builds the devkit

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -551,6 +551,10 @@ optee-os-common:
 optee-os-clean-common:
 	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS) clean
 
+.PHONY: optee-os-devkit
+optee-os-devkit:
+	$(MAKE) -C $(OPTEE_OS_PATH) $(OPTEE_OS_COMMON_FLAGS) ta_dev_kit
+
 ################################################################################
 # fTPM Rules
 ################################################################################
@@ -568,7 +572,7 @@ FTPM_FLAGS ?= 						\
 .PHONY: ftpm
 ftpm:
 ifeq ($(MEASURED_BOOT_FTPM),y)
-ftpm: optee-os
+ftpm: optee-os-devkit
 	$(FTPM_FLAGS) $(MAKE) -C $(FTPM_PATH)
 endif
 


### PR DESCRIPTION
Adds build target `optee-os-devkit` to get the TA devkit be built and installed. It can be later used as a dependency when building external TAs that need to build linked to OP-TEE as early TAs where building OP-TEE core depends on such TAs being already built. This applies to ftpm hence replace the dependency of `ftpm` make target with a dependency on `optee-os-devkit`.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
