### PR TITLE
optee_rust_examples_ext: Fix Rust toolchain conflicts

### DIFF
--- a/br-ext/package/optee_rust_examples_ext/Config.in
+++ b/br-ext/package/optee_rust_examples_ext/Config.in
@@ -52,4 +52,10 @@ config BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_CROSS_COMPILE_TA
 	  the target platforms. Hence this options provides path to GCC linker
 	  in order to link TA part of the Rust examples. For example:
 	  aarch64-linux-gnu- or path/to/aarch64-linux-gnu-
+
+config BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TC_PATH
+	string "OP-TEE Rust toolchain installation path"
+	default ""
+	help
+	  The path to OP-TEE Rust toolchain installation directory
 endif

--- a/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
+++ b/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
@@ -5,11 +5,28 @@ OPTEE_RUST_EXAMPLES_EXT_SITE_METHOD = local
 OPTEE_RUST_EXAMPLES_EXT_INSTALL_STAGING = YES
 OPTEE_RUST_EXAMPLES_EXT_DEPENDENCIES = optee_client_ext
 OPTEE_RUST_EXAMPLES_EXT_SDK = $(BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_SDK)
+OPTEE_RUST_EXAMPLES_EXT_TC_PATH = $(subst $\",,$(BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TC_PATH))
 
 EXAMPLE = $(wildcard examples/*)
 
+define OPTEE_RUST_EXAMPLES_EXT_CONFIGURE_CMDS
+	# Ensure the toolchain, components, and targets we've specified in
+	# rust-toolchain.toml are ready to go. Since that file sets rustup's
+	# default toolchain for the entire directory, all we need to do is run
+	# any rustup-wrapped command to trigger installation. We've arbitrarily
+	# chosen "cargo --version" since it has no other effect.
+	@echo Configuring OP-TEE rust examples && \
+	export RUSTUP_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.rustup && \
+	export CARGO_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo && \
+	source $(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo/env && \
+	cd $(@D) && cargo --version >/dev/null
+endef
+
 define OPTEE_RUST_EXAMPLES_EXT_BUILD_CMDS
-	echo Building OP-TEE rust examples && \
+	@echo Building OP-TEE rust examples && \
+	export RUSTUP_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.rustup && \
+	export CARGO_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo && \
+	source $(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo/env && \
 	TARGET_HOST=$(BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TARGET_HOST) \
 	TARGET_TA=$(BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TARGET_TA) \
 	CROSS_COMPILE_HOST=$(BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_CROSS_COMPILE_HOST) \

--- a/common.mk
+++ b/common.mk
@@ -289,6 +289,7 @@ BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TARGET_HOST ?= "$(AARCH$(COMPILE_NS_USER)_RU
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TARGET_TA ?= "$(AARCH$(COMPILE_S_USER)_RUST_TARGET)"
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_SDK ?= $(OPTEE_OS_TA_DEV_KIT_DIR)
 BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_SITE ?= $(OPTEE_RUST_PATH)
+BR2_PACKAGE_OPTEE_RUST_EXAMPLES_EXT_TC_PATH ?= $(RUST_TOOLCHAIN_PATH)
 endif
 endif
 # The OPTEE_OS package builds nothing, it just installs files into the
@@ -349,7 +350,7 @@ buildroot: optee-os
 		$(DEFCONFIG_FTPM) \
 		--br-defconfig out-br/extra.conf \
 		--make-cmd $(MAKE))
-	@source $(RUST_TOOLCHAIN_PATH)/.cargo/env && $(MAKE) $(br-make-flags) -C ../out-br all
+	@$(MAKE) $(br-make-flags) -C ../out-br all
 
 .PHONY: buildroot-clean
 buildroot-clean:

--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -30,7 +30,7 @@ QEMU_VIRTFS_AUTOMOUNT = y
 endif
 
 # Option to enable Rust examples
-RUST_ENABLE ?= n
+RUST_ENABLE ?= y
 
 include common.mk
 

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -75,11 +75,7 @@ define dl-rust-toolchain
 		mkdir -p $(1) && \
 		export RUSTUP_HOME=$(1)/.rustup && \
 		export CARGO_HOME=$(1)/.cargo && \
-		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path && \
-		source "$(1)/.cargo/env" && \
-		rustup target install aarch64-unknown-linux-gnu && \
-		rustup target install arm-unknown-linux-gnueabihf && \
-		rustup default nightly-2023-12-18; \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path; \
 	fi
 endef
 


### PR DESCRIPTION
Buildroot provides its own Rust toolchain for various Linux user-space
components. However, that toolchain doesn't support nightly version of
Rust complier which we need for OP-TEE Rust examples for the time being.

Due to two separate Rust toolchains being used for different buildroot
components, there are conflicts [1] [2] observed leading to CI errors.
In order to fix them enable OP-TEE specific Rust toolchain specifically
to build OP-TEE Rust examples rather than enabling it for the entire
buildroot build.

Fixes: [1] https://github.com/OP-TEE/build/issues/727
Fixes: [2] https://github.com/OP-TEE/build/issues/728

@DemesneGH fyi..