### PR TITLE
qemuv8: rust.exp: increase timeout to 60 seconds

### DIFF
--- a/rust.exp
+++ b/rust.exp
@@ -4,7 +4,7 @@
 # success, >0 for error.
 #
 
-set timeout 10
+set timeout 60
 
 info "Test Rust example applications:\n"
 info "Running acipher-rs...\n"


### PR DESCRIPTION
A timeout of 10 seconds is enough in most cases, but for some debug configurations where OP-TEE runs very slowly ([1], [2]) the signature_verification-rs test may not complete in time. Therefore increase the timeout to 60 seconds.

[1] `make check CHECK_TESTS=rust \`
`        CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFLAGS_ta_arm64=-pg`
[2] `make check CHECK_TESTS=rust \`
`        CFG_CORE_DEBUG_CHECK_STACKS=y CFG_STACK_THREAD_EXTRA=256`

