### PR TITLE
optee_test_ext.mk: use the optee_test Makefile to build TAs

### DIFF
--- a/br-ext/package/optee_test_ext/optee_test_ext.mk
+++ b/br-ext/package/optee_test_ext/optee_test_ext.mk
@@ -29,30 +29,18 @@ define OPTEE_TEST_EXT_PREPARE_GP_SUITE
 endef
 
 define OPTEE_TEST_EXT_BUILD_TAS
-	@$(foreach f,$(call uniq,$(foreach t,$(OPTEE_TEST_EXT_TAS),$(wildcard $(@D)/ta/$(t)/Makefile))), \
-		echo Building $f && \
-			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_EXT_CROSS_COMPILE))" \
-			O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_EXT_SDK) \
-			PYTHON3=$(HOST_DIR)/bin/python3 \
-			$(TARGET_CONFIGURE_OPTS) -C $(dir $f) all &&) true
+	$(MAKE) -j$$(nproc) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_EXT_CROSS_COMPILE))" \
+		O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_EXT_SDK) \
+		PYTHON3=$(HOST_DIR)/bin/python3 \
+		$(TARGET_CONFIGURE_OPTS) -C $(BUILD_DIR)/optee_test_ext-$(OPTEE_TEST_EXT_VERSION)/ta -f $(@D)/ta/Makefile.gmake all
 endef
 
 define OPTEE_TEST_EXT_INSTALL_TAS
-	@$(foreach f,$(wildcard $(@D)/ta/*/out/*.ta), \
+	@$(foreach f,$(wildcard $(@D)/ta/*/out/ta/*/*.ta), \
 		mkdir -p $(TARGET_DIR)/lib/optee_armtz && \
 		$(INSTALL) -v -p  --mode=444 \
 			--target-directory=$(TARGET_DIR)/lib/optee_armtz $f \
 			&&) true
-endef
-
-
-define OPTEE_TEST_EXT_BUILD_GP_TAS
-	@$(foreach f,$(wildcard $(shell echo $(@D)/host/xtest/gp-suite/TTAs_Internal_API_1_1_1/*/*/{*/,}code_files/Makefile)), \
-		echo Building $f && \
-			$(MAKE) CROSS_COMPILE="$(shell echo $(BR2_PACKAGE_OPTEE_TEST_EXT_CROSS_COMPILE))" \
-			O=out TA_DEV_KIT_DIR=$(OPTEE_TEST_EXT_SDK) \
-			$(TARGET_CONFIGURE_OPTS) -C $(dir $f) all &&) true
-
 endef
 
 define OPTEE_TEST_EXT_INSTALL_GP_TAS
@@ -64,7 +52,6 @@ define OPTEE_TEST_EXT_INSTALL_GP_TAS
 endef
 
 OPTEE_TEST_EXT_POST_BUILD_HOOKS += OPTEE_TEST_EXT_BUILD_TAS
-OPTEE_TEST_EXT_POST_BUILD_HOOKS += OPTEE_TEST_EXT_BUILD_GP_TAS
 OPTEE_TEST_EXT_POST_INSTALL_TARGET_HOOKS += OPTEE_TEST_EXT_INSTALL_TAS
 OPTEE_TEST_EXT_POST_INSTALL_TARGET_HOOKS += OPTEE_TEST_EXT_INSTALL_GP_TAS
 


### PR DESCRIPTION
Rather than enumerating all the TAs and invoking each Makefile individually (optee_test/ta/<ta_name>/Makefile), user the higher level Makefile (optee_test/ta/Makefile.gmake). This makes things simpler here and less fragile if something changes in optee_test. In addition, this should fix an "Argument list too long" error that can happen depending on the environment [1]. Finally, TAs can now be built in parallel (make -jN).

Link: https://github.com/OP-TEE/build/issues/744 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
