### PR TITLE
stm32mp1: use tee-supplicant option --unique-rpmb

### DIFF
--- a/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-rootfs-rpmb/etc/init.d/S30optee
+++ b/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-rootfs-rpmb/etc/init.d/S30optee
@@ -5,10 +5,12 @@
 #
 # tee-supplicant is run as root user ID to access /dev/teepriv0
 # and eMMC resources including its RPMB partition.
+# The board has a single eMMC device so ask tee-supplicant to find it
+# (--unique-rpmb)
 
 DAEMON="tee-supplicant"
 DAEMON_PATH="/usr/sbin"
-DAEMON_ARGS="-d /dev/teepriv0"
+DAEMON_ARGS="-d /dev/teepriv0 --unique-rpmb"
 PIDFILE="/var/run/$DAEMON.pid"
 
 start() {


### PR DESCRIPTION
Use **tee-supplicant** recently added option `--unique-rpmb` to let **tee-supplicant** find the unique RPMB partition device file since Linux kernels v6.2 and later do not guaranty the mmcblk device index passed to OP-TEE configuration option `CFG_RPMB_FS_DEV_ID` is reliable.

This change depends on https://github.com/OP-TEE/optee_client/pull/381.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
