### PR TITLE
qemu: align run and check on qemu_v8

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -4,7 +4,6 @@
 # tests in the guest. The return code is 0 for success, >0 for error.
 #
 # Options:
-#   --bios    Path to the binary to be run [../out/bios-qemu/bios.bin]
 #   -q        Suppress output to stdout (quiet)
 #   --tests   Type of tests to run, values: all, xtest and trusted-keys
 #   --timeout Timeout for each test (sub)case, in seconds [480]
@@ -40,7 +39,6 @@ set myargs $argv
 while {[llength $myargs]} {
 	set myargs [lassign $myargs arg]
 	switch -exact -- $arg {
-		"--bios"	{set myargs [lassign $myargs ::bios]}
 		"--tests"	{set myargs [lassign $myargs ::tests]}
 		"--timeout"	{set myargs [lassign $myargs ::timeout]}
 		"-q"		{set ::quiet 1}
@@ -114,11 +112,7 @@ info "Starting QEMU..."
 open "serial1.log" "w+"
 spawn -open [open "|tail -f serial1.log"]
 set teecore $spawn_id
-if {[string first "aarch64" $::env(QEMU)] != -1} {
-	spawn sh -c "$::env(QEMU) $::env(QEMU_CHECK_ARGS)"
-} else {
-	spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable=on,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
-}
+spawn sh -c "$::env(QEMU) $::env(QEMU_CHECK_ARGS)"
 expect {
 	"Kernel panic" {
 		info "!!! Kernel panic\n"


### PR DESCRIPTION
Commit 71977485810c ("qemu_v8: Rework the QEMU arguments for run and check") has introduced QEMU_BASE_ARGS, QEMU_RUN_ARGS and QEMU_CHECK_ARGS in qemu_v8.mk. While doing so it inadvertently broke QEMU_VIRTFS_AUTOMOUNT=y / QEMU_VIRTFS_ENABLE=y / QEMU_PSS_ENABLE=y because those flags now add things to QEMU_RUN_ARGS rather than to QEMU_EXTRA_ARGS.
Therefore, change qemu.mk in a similar way to qemu_v8.mk and simplify a couple of things in qemu_check.exp.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
