### PR TITLE
qemu_v8: enable max CPU for Xen

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -489,27 +489,29 @@ run: all
 
 
 ifeq ($(XEN_BOOT),y)
-QEMU_CPU	?= cortex-a57
-QEMU_MEM 	?= 3072
-QEMU_SMP	?= 4
 QEMU_VIRT	= true
-QEMU_XEN	?= -drive if=none,file=$(XEN_EXT4),format=raw,id=hd1 \
-		   -device virtio-blk-device,drive=hd1
-else
-ifeq ($(SPMC_AT_EL),2)
+else ifeq ($(SPMC_AT_EL),2)
 QEMU_VIRT	= true
 else
 QEMU_VIRT	= false
 endif
+
+ifeq ($(XEN_BOOT),y)
+QEMU_MEM 	?= 3072
+QEMU_SMP	?= 4
+QEMU_XEN	?= -drive if=none,file=$(XEN_EXT4),format=raw,id=hd1 \
+		   -device virtio-blk-device,drive=hd1
+else
+QEMU_SMP 	?= 2
+QEMU_MEM 	?= 1057
+endif
+
 ifeq ($(SPMC_AT_EL),n)
 QEMU_SME	= on
 else
 QEMU_SME	= off
 endif
 QEMU_CPU	?= max,sme=$(QEMU_SME),pauth-impdef=on
-QEMU_SMP 	?= 2
-QEMU_MEM 	?= 1057
-endif
 
 ifeq ($(MEMTAG),y)
 QEMU_MTE	= on


### PR DESCRIPTION
Enable the QEMU max CPU for Xen. With this change simplify the configuration a little.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
