### PR TITLE
stm32mp1: retrieve unique eMMC CID for tee-supplicant

### DIFF
--- a/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-rootfs-rpmb/etc/init.d/S30optee
+++ b/br-ext/board/stmicroelectronics/stm32mp1-tz/overlay-rootfs-rpmb/etc/init.d/S30optee
@@ -5,6 +5,9 @@
 #
 # tee-supplicant is run as root user ID to access /dev/teepriv0
 # and eMMC resources including its RPMB partition.
+#
+# If a unique eMMC device is found on the system, retrieve its CID
+# and pass it to tee-supplcant.
 
 DAEMON="tee-supplicant"
 DAEMON_PATH="/usr/sbin"
@@ -21,6 +24,19 @@ start() {
 		echo "FAIL"
 		return "$status"
 	fi
+	# Find eMMC CID if only 1 eMMC device is found
+	CID=""
+	for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do
+	  # POSIX shells don't expand globbing patterns that match no file
+	  [ -e $f ] || break
+	  devtype=$(echo $f | sed 's/cid/type/')
+	  [ ! -e $devtype ] && continue
+	  [ "$(cat $devtype)" != "MMC" ] && continue
+	  [ "$CID" ] && { echo $0: Multiple eMMC devices found, not chosing one automatically >&2; break; }
+	  CID=$(cat $f)
+	done
+	[ "$CID" ] && DAEMON_ARGS="$DAEMON_ARGS --rpmb-cid $CID"
+	# Start tee-supplicant daemon
 	printf 'Starting %s: ' "$DAEMON"
 	start-stop-daemon -S -q -p "$PIDFILE" -c root -x "$DAEMON_PATH/$DAEMON" \
 		-- $DAEMON_ARGS


### PR DESCRIPTION
Retrieve the eMMC CID if only one eMMC device is found. We expect it to be used for OP-TEE RPMB secure storage. This change allows OS based on Linux kernel v6.2 or later to be more reliable on identifying the eMMC mmcblk device as since Linux kernel v6.2 the device index assigned by the kernel may change from one cold boot to another when they are several mmcblk devices on the platform, for example a plugged SD card and a soldered eMMC device.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
