### PR TITLE
toolchains.mk, get_clang.sh: upgrade to Clang 18.1.6

### DIFF
--- a/get_clang.sh
+++ b/get_clang.sh
@@ -7,43 +7,19 @@
 # Clang is configured to be able to cross-compile to all the supported
 # architectures by default (see <clang path>/bin/llc --version) which is great,
 # but compiler-rt is included only for the host architecture. Therefore we need
-# to combine several packages into one, which is the purpose of this script.
+# a custom build of clang, which is achieved by [1].
+# This script retrieves a pre-compiled image from the Docker Hub and extracts
+# the compiler.
 
 [ "$1" ] || { echo "Usage: get_clang.sh version [path]"; exit 1; }
 
 VER=${1}
 DEST=${2:-./clang-${VER}}
-X86_64=clang+llvm-${VER}-x86_64-linux-gnu-ubuntu-16.04
-AARCH64=clang+llvm-${VER}-aarch64-linux-gnu
-ARMV7A=clang+llvm-${VER}-armv7a-linux-gnueabihf
 
-set -x
+ARCH=$(uname -m)
+set -e -x
 
-TMPDEST=${DEST}_tmp${RANDOM}
-
-if [ -e ${TMPDEST} ]; then
-  echo Error: ${TMPDEST} exists
-  exit 1
-fi
-
-function cleanup() {
-  rm -f ${X86_64}.tar.xz ${AARCH64}.tar.xz ${ARMV7A}.tar.xz
-  rm -rf ${AARCH64} ${ARMV7A}
-}
-
-trap "{ exit 2; }" INT
-trap cleanup EXIT
-
-(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${X86_64}.tar.xz && tar xf ${X86_64}.tar.xz) &
-pids=$!
-(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${AARCH64}.tar.xz && tar xf ${AARCH64}.tar.xz) &
-pids="$pids $!"
-(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${ARMV7A}.tar.xz && tar xf ${ARMV7A}.tar.xz) &
-pids="$pids $!"
-
-wait $pids || exit 1
-
-mv ${X86_64} ${TMPDEST} || exit 1
-cp ${AARCH64}/lib/clang/${VER}/lib/linux/* ${TMPDEST}/lib/clang/${VER}/lib/linux || exit 1
-cp ${ARMV7A}/lib/clang/${VER}/lib/linux/* ${TMPDEST}/lib/clang/${VER}/lib/linux || exit 1
-mv ${TMPDEST} ${DEST}
+id=$(docker create jforissier/clang-${VER}-${ARCH})
+docker cp $id:/root/clang-${VER} ${DEST}
+docker rm ${id}
+docker rmi jforissier/clang-${VER}-${ARCH}

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -82,7 +82,7 @@ aarch64-toolchain:
 rust-toolchain:
 	$(call dl-rust-toolchain,$(RUST_TOOLCHAIN_PATH))
 
-CLANG_VER			?= 12.0.0
+CLANG_VER			?= 18.1.6
 CLANG_PATH			?= $(ROOT)/clang-$(CLANG_VER)
 
 # Download the Clang compiler with LLVM tools and compiler-rt libraries


### PR DESCRIPTION
Update the Clang version from 12.0.0 to 18.1.6. Unfortunately, newer versions of the LLVM toolchain do not make available the pre-built compiler-rt packages for arm64 and armhf. Therefore, the way we obtain the toolchain is changed. I created a project with a Makefile and a Dockerfile [1] which allows to build Clang from scratch with the proper compiler-rt libraries for OP-TEE cross-compilation. Nothing really special, yet not a configuration that is availale pre-built in the major Linux distributions (Unbuntu). The problem is that on an x84_64 system, there is no way to install the compiler-rt builtins for a different architecture (libclang_rt.builtins-{aarch64,armhf}.a).

The new method to install Clang is thererfore to pull a pre-built image (called jforissier/clang-<version>-<arch>) from the Docker Hub, then simply extract the files contained inside, which is what the modified get_clang.sh does.

Link: https://github.com/jforissier/docker_clang [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
