### PR TITLE
toolchain.mk: add clang-toolchains-build to build Clang from sources

### DIFF
--- a/clang/Dockerfile
+++ b/clang/Dockerfile
@@ -1,0 +1,82 @@
+ARG VER_MAJ
+ARG VER
+ARG INSTALL_DIR=/root/install
+
+FROM ubuntu:22.04 as clang-build
+ARG VER_MAJ
+ARG VER
+ARG INSTALL_DIR
+RUN apt update -y && apt install -y \
+	cmake \
+	g++ \
+	gcc \
+	gcc-aarch64-linux-gnu \
+	gcc-arm-linux-gnueabihf \
+	git \
+	ninja-build \
+	python3
+WORKDIR /root
+RUN git clone --depth=1 -b llvmorg-${VER}  https://github.com/llvm/llvm-project.git
+
+RUN mkdir /root/build
+WORKDIR /root/build
+RUN cmake ../llvm-project/llvm -G Ninja \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+	-DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" \
+	-DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
+	-DBUILD_SHARED_LIBS=ON
+RUN ninja install
+
+RUN mkdir /root/build-rt-armhf
+WORKDIR /root/build-rt-armhf
+RUN cmake ../llvm-project/compiler-rt -G Ninja \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/lib/clang/${VER_MAJ} \
+	-DCMAKE_AR=${INSTALL_DIR}/bin/llvm-ar \
+	-DCMAKE_ASM_COMPILER_TARGET="arm-linux-gnueabihf" \
+	-DCMAKE_ASM_FLAGS="--target=arm-linux-gnueabihf -march=armv7a -mthumb" \
+	-DCMAKE_C_COMPILER=${INSTALL_DIR}/bin/clang \
+	-DCMAKE_C_COMPILER_TARGET="arm-linux-gnueabihf" \
+	-DCMAKE_C_FLAGS="--target=arm-linux-gnueabihf -march=armv7a -mthumb" \
+	-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+	-DCMAKE_NM=${INSTALL_DIR}/bin/llvm-nm \
+	-DCMAKE_RANLIB=${INSTALL_DIR}/bin/llvm-ranlib \
+	-DCOMPILER_RT_BUILD_BUILTINS=ON \
+	-DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+	-DCOMPILER_RT_BUILD_MEMPROF=OFF \
+	-DCOMPILER_RT_BUILD_PROFILE=OFF \
+	-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+	-DCOMPILER_RT_BUILD_XRAY=OFF \
+	-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+	-DLLVM_CONFIG_PATH=${INSTALL_DIR}/bin/llvm-config
+RUN ninja install
+
+RUN mkdir /root/build-rt-aarch64
+WORKDIR /root/build-rt-aarch64
+RUN cmake ../llvm-project/compiler-rt -G Ninja \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/lib/clang/${VER_MAJ} \
+	-DCMAKE_AR=${INSTALL_DIR}/bin/llvm-ar \
+	-DCMAKE_ASM_COMPILER_TARGET="aarch64-linux-gnu" \
+	-DCMAKE_C_COMPILER=${INSTALL_DIR}/bin/clang \
+	-DCMAKE_C_COMPILER_TARGET="aarch64-linux-gnu" \
+	-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+	-DCMAKE_NM=${INSTALL_DIR}/bin/llvm-nm \
+	-DCMAKE_RANLIB=${INSTALL_DIR}/bin/llvm-ranlib \
+	-DCOMPILER_RT_BUILD_BUILTINS=ON \
+	-DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+	-DCOMPILER_RT_BUILD_MEMPROF=OFF \
+	-DCOMPILER_RT_BUILD_PROFILE=OFF \
+	-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+	-DCOMPILER_RT_BUILD_XRAY=OFF \
+	-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+	-DLLVM_CONFIG_PATH=${INSTALL_DIR}/bin/llvm-config
+RUN ninja install
+
+FROM scratch
+ARG VER
+ARG INSTALL_DIR
+WORKDIR /root
+COPY --from=clang-build ${INSTALL_DIR} /root/clang-${VER}
+ENTRYPOINT null

--- a/toolchain.mk
+++ b/toolchain.mk
@@ -158,3 +158,16 @@ $(AARCH64_PATH)/.done:
 $(AARCH32_PATH)/.done:
 	$(call build_toolchain,aarch32,$(AARCH32_PATH),arm,gnueabihf)
 endif
+
+# Recipe to build Clang from sources and install it in
+# $(TOOLCHAIN_ROOT)/clang-x.y.z/bin
+
+CLANG_BUILD_VER_MAJ=18
+CLANG_BUILD_VER=$(CLANG_BUILD_VER_MAJ).1.7
+CLANG_BUILD_IMAGE=clang-$(CLANG_BUILD_VER)-$(UNAME_M)
+
+clang-toolchains-build:
+	docker build --build-arg VER_MAJ=$(CLANG_BUILD_VER_MAJ) --build-arg VER=$(CLANG_BUILD_VER) -t $(CLANG_BUILD_IMAGE) clang/
+	id=$$(docker create $(CLANG_BUILD_IMAGE)) && \
+		docker cp $${id}:/root/clang-$(CLANG_BUILD_VER) $(TOOLCHAIN_ROOT) && \
+		docker rm $${id}


### PR DESCRIPTION
Add a makefile target to download and build the Clang 18.1.7 sources and install the compiler into <PRJ_ROOT>/toolchains/clang-18.1.7/bin.

Usage example:

 $ make clang-toolchains-build
 $ PATH=$(pwd)/../toolchains/clang-18.1.7/bin:$PATH \
     make -j$(nproc) COMPILER=clang check

The Clang build takes some significant time (about 12 minutes on my machine, a 24-core Intel Core i9-12900K) so may want to store a pre-built package somewhere in the future and have "make clang-toolchains" download that package. In the mean time, this new target allows to test OP-TEE with a recent LLVM toolchain.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
