### PR TITLE
qemuv8: fix to enable Rust by default on x86_64 hosts only

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -31,7 +31,7 @@ endif
 
 # Option to enable Rust examples
 # Currently supported only on x86_64 hosts
-ifeq ($(UNAME_M),x86_64)
+ifeq ($(shell uname -m),x86_64)
 RUST_ENABLE ?= y
 endif
 


### PR DESCRIPTION
Change (UNAME_M) to (shell uname -m) to detect host, so that "RUST_ENABLE" can be correctly set on x86_64 hosts.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
