### PR TITLE
qemuv8: rust.exp: increase timeout of signature verification to 400s

### DIFF
--- a/rust.exp
+++ b/rust.exp
@@ -164,6 +164,9 @@ expect {
 
 expect "# "
 info "Running signature_verification-rs...\n"
+# This one can take up to 6 minutes when CFG_CORE_DEBUG_CHECK_STACKS=y
+# (3-4 minutes is common on my machine)
+set timeout 400
 send -- "signature_verification-rs\r"
 expect {
 	"Success" {


### PR DESCRIPTION
Since optee_os commit b05636319287 ("Squashed commit upgrading to mbedtls-3.6.0"), the signature-verification-rs test takes a lot more time when CFG_CORE_DEBUG_CHECK_STACKS=y. Here are some values reported by "time signature-verification-rs" on QEMUv8:

  [CFG_CORE_DEBUG_CHECK_STACKS=y]
  Before: 0m 30s ; 0m 39s ; 0m 28s
  After: 3m 8s ; 2m 13s ; 6m 36s ; 4m 14s

  [CFG_CORE_DEBUG_CHECK_STACKS=n]
  Before: 0m 1.55s ; 0m 1.57s ; 0m 1.77s 0m 0.87s
  After: 0m 2.69s ; 0m 1.20s ; 0m 1.61s ; 0m 1.73s

Therefore, increase the timeout for this test specifically.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
