### PR TITLE
common.mk post-build.sh S30optee: change /data to /var/lib

### DIFF
--- a/br-ext/board/qemu/post-build.sh
+++ b/br-ext/board/qemu/post-build.sh
@@ -36,8 +36,8 @@ if [[ $VIRTFS_AUTOMOUNT == "y" ]]; then
 fi
 
 if [[ $PSS_AUTOMOUNT == "y" ]]; then
-    mkdir -p "$TARGETDIR"/data/tee
+    mkdir -p "$TARGETDIR"/var/lib/tee
     grep secure "$TARGETDIR"/etc/fstab > /dev/null || \
-    echo "secure /data/tee 9p trans=virtio,version=9p2000.L,msize=65536,rw 0 0" >> "$TARGET_DIR"/etc/fstab
+    echo "secure /var/lib/tee 9p trans=virtio,version=9p2000.L,msize=65536,rw 0 0" >> "$TARGET_DIR"/etc/fstab
     echo "[+] persistent secure storage mount added to fstab"
 fi

--- a/br-ext/package/optee_client_ext/S30optee
+++ b/br-ext/package/optee_client_ext/S30optee
@@ -19,8 +19,8 @@ start() {
 		echo "FAIL"
 		return "$status"
 	fi
-	printf 'Create/set permissions on %s: ' "/data/tee"
-	mkdir -p /data/tee && chown -R tee:tee /data/tee && chmod 0770 /data/tee
+	printf 'Create/set permissions on %s: ' "/var/lib/tee"
+	mkdir -p /var/lib/tee && chown -R tee:tee /var/lib/tee && chmod 0770 /var/lib/tee
 	status=$?
 	if [ "$status" -eq 0 ]; then
 		echo "OK"

--- a/common.mk
+++ b/common.mk
@@ -59,7 +59,7 @@ CCACHE ?= $(shell which ccache) # Don't remove this comment (space is needed)
 # 1) make QEMU_VIRTFS_AUTOMOUNT=y run
 #    will mount the project's root on the host as /mnt/host in QEMU.
 # 2) mkdir -p /tmp/qemu-data-tee && make QEMU_PSS_AUTOMOUNT=y run
-#    will mount the host directory /tmp/qemu-data-tee as /data/tee
+#    will mount the host directory /tmp/qemu-data-tee as /var/lib/tee
 #    in QEMU, thus creating persistent secure storage.
 
 ifeq ($(QEMU_VIRTFS_AUTOMOUNT),y)
@@ -85,7 +85,7 @@ QEMU_VIRTFS_HOST_DIR	?= $(ROOT)
 # Persistent Secure Storage via shared folder
 # # Set QEMU_PSS_ENABLE to 'y' and adjust QEMU_PSS_HOST_DIR
 # # Then in QEMU, run:
-# # $ mount -t 9p -o trans=virtio secure /data/tee
+# # $ mount -t 9p -o trans=virtio secure /var/lib/tee
 # # Or enable QEMU_PSS_AUTOMOUNT
 QEMU_PSS_ENABLE		?= n
 QEMU_PSS_HOST_DIR	?= /tmp/qemu-data-tee


### PR DESCRIPTION
/data/tee is not FHS compatible path. Use /var/lib/tee instead. Related to optee_client side CMake change to use standard CMake install and runtime paths:
https://github.com/OP-TEE/optee_client/pull/391

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
