### PR TITLE
fvp: Add libpsats support

### DIFF
--- a/fvp-psa-sp.mk
+++ b/fvp-psa-sp.mk
@@ -154,6 +154,7 @@ endif
 # Linux user space applications
 ifeq ($(SPMC_TESTS),n)
 $(eval $(call build-ts-app,libts,$(TS_APP_LIBTS_EXTRA_FLAGS)))
+$(eval $(call build-ts-app,libpsats,$(TS_APP_LIBPSATS_EXTRA_FLAGS)))
 $(eval $(call build-ts-app,ts-service-test,$(TS_APP_TS_SERVICE_TEST_EXTRA_FLAGS)))
 $(eval $(call build-ts-app,psa-api-test/internal_trusted_storage,$(TS_APP_PSA_ITS_EXTRA_FLAGS)))
 $(eval $(call build-ts-app,psa-api-test/protected_storage,$(TS_APP_PSA_PS_EXTRA_FLAGS)))

--- a/trusted-services.mk
+++ b/trusted-services.mk
@@ -153,11 +153,19 @@ ffa-$1:
 		-DCMAKE_INSTALL_PREFIX=$(TS_INSTALL_PREFIX) \
 		-Dlibts_DIR=${TS_INSTALL_PREFIX}/arm-linux/lib/cmake/libts \
 		-DCFG_FORCE_PREBUILT_LIBTS=On \
+		-Dlibpsats_DIR=${TS_INSTALL_PREFIX}/arm-linux/lib/cmake/libpsats \
+		-DCFG_FORCE_PREBUILT_LIBPSATS=On \
 		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) $(TS_APP_COMMON_FLAGS) $2
 	$$(MAKE) -C $(TS_BUILD_PATH)/$1 install
 
 ifneq ($1,libts)
-ffa-$1: ffa-libts
+
+ifeq ($1,libpsats)
+ffa-libpsats: ffa-libts
+else
+ffa-$1: ffa-libpsats
+endif
+
 endif
 
 .PHONY: ffa-$1-clean


### PR DESCRIPTION
TS introduced a new shared library to help userspace applications integrate PSA clients. To avoid building this library multiple times add a dedicated build step, and share the resulting binary with all dependees.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
