### PR TITLE
qemuv8: fix arm-tf link error on aarch64 build hosts

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -146,7 +146,8 @@ include toolchain.mk
 ################################################################################
 TF_A_EXPORTS ?= \
 	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" \
-	CC="$(CCACHE)$(AARCH64_CROSS_COMPILE)gcc"
+	CC="$(CCACHE)$(AARCH64_CROSS_COMPILE)gcc" \
+	LD="$(CCACHE)$(AARCH64_CROSS_COMPILE)ld"
 
 TF_A_DEBUG ?= $(DEBUG)
 ifeq ($(TF_A_DEBUG),0)


### PR DESCRIPTION
When building on an aarch64 host, the following error occurs:

   LD      /optee/trusted-firmware-a/build/qemu/release/bl31/bl31.elf
 /optee/toolchains/aarch64/bin/../lib/gcc/aarch64-buildroot-linux-gnu/14.1.0/../../../../aarch64-buildroot-linux-gnu/bin/ld: /optee/trusted-firmware-a/build/qemu/release/bl1/bl1.elf: error: PHDR segment not covered by LOAD segment
 collect2: error: ld returned 1 exit status
 make[1]: *** [Makefile:1528: /optee/trusted-firmware-a/build/qemu/release/bl1/bl1.elf] Error 1

Setting LD and *not* setting CROSS_COMPILE fixes the problem. Tested on an aarch64 server running Ubuntu 24.04.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
