### PR TITLE
stm32mp1: support build for TF-A v2.11 and later

### DIFF
--- a/stm32mp1.mk
+++ b/stm32mp1.mk
@@ -192,7 +192,9 @@ optee-os-clean: optee-os-clean-common
 ################################################################################
 # TrustedFirmware-A
 ################################################################################
-TFA_EXPORTS ?= CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
+TFA_EXPORTS ?= CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)" \
+	       CC="$(CCACHE)$(AARCH32_CROSS_COMPILE)gcc" \
+	       LD="$(CCACHE)$(AARCH32_CROSS_COMPILE)ld"
 
 TFA_DEBUG ?= $(DEBUG)
 ifeq ($(TFA_DEBUG),0)


### PR DESCRIPTION
Building TF-A v2.11-rc0 and later fails when CROSS_COMPILE command includes space characters as when using ccache directives. This seems to be fixed by setting CC to the ccache and cross-toolchain directive.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
