### PR TITLE
Revert "qemu_v8.mk: enable MEASURED_BOOT_FTPM by default"

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -35,9 +35,6 @@ ifeq ($(shell uname -m),x86_64)
 RUST_ENABLE ?= y
 endif
 
-# Enable fTPM
-MEASURED_BOOT_FTPM ?= y
-
 include common.mk
 
 DEBUG ?= 1


### PR DESCRIPTION
This reverts commit 9bf2bbe57184bb2c6ba73eacb2b11b7eeee40962. CI has become quite unstable since that commit was merged, see for instance the multiple failures in [1] and the absence of failure in [2]. I do not see any direct relationship betweem fTPM and the errors reported in the CI runs, but in order to make CI useful again we need to have it run reliably so disable MEASURED_BOOT_FTPM temporarily.

In my tests, 'make -j$(nproc) check-only XTEST_ARGS="-l 14"' always failed with a TA panic when MEASURED_BOOT_FTPM=y, and never when it is =n. The panic sometimes happens in xtest regression_4006, or sometimes in pkcs11_1021 or pkcs11_1023.

Link: [1] https://github.com/OP-TEE/optee_os/pull/7170
Link: [2] https://github.com/OP-TEE/optee_os/pull/7175

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
