### PR TITLE
qemu_v8.mk: re-enable MEASURED_BOOT_FTPM by default

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -35,6 +35,9 @@ ifeq ($(shell uname -m),x86_64)
 RUST_ENABLE ?= y
 endif
 
+# Enable fTPM
+MEASURED_BOOT_FTPM ?= y
+
 include common.mk
 
 DEBUG ?= 1


### PR DESCRIPTION
By default, enable MEASURED_BOOT_FTPM. The previous issues when MEASURED_BOOT_FTPM was enabled has been resolved in [1].

Link: [1] https://github.com/OP-TEE/optee_os/pull/7177

Acked-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
