### PR TITLE
qemu: fix path to QEMU

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -170,9 +170,9 @@ QEMU_RUN_ARGS = $(QEMU_BASE_ARGS)
 QEMU_RUN_ARGS += $(QEMU_RUN_ARGS_COMMON)
 QEMU_RUN_ARGS += -s -S -serial tcp:127.0.0.1:$(QEMU_NW_PORT) -serial tcp:127.0.0.1:$(QEMU_SW_PORT)
 
-# The aarch64-softmmu part of the path to qemu-system-aarch64 was removed
+# The arm-softmmu part of the path to qemu-system-arm was removed
 # somewhere between 8.1.2 and 9.1.2
-QEMU_BIN = $(or $(wildcard $(QEMU_BUILD)/qemu-system-aarch64),$(wildcard $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64),qemu-system-aarch64-not-found)
+QEMU_BIN = $(or $(wildcard $(QEMU_BUILD)/qemu-system-arm),$(wildcard $(QEMU_BUILD)/arm-softmmu/qemu-system-arm),qemu-system-arm-not-found)
 
 .PHONY: run-only
 run-only:


### PR DESCRIPTION
The name of the QEMU v7 binary is qemu-system-arm not qemu-system-aarch64, so fix it.

Fixes: 329573518db6 ("qemu: support new path to QEMU v9.2.0")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
