### PR TITLE
qemu-check.exp: catch more RCU messages

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -62,7 +62,7 @@ proc check_test_result arg {
 			info " $expect_out(1,string) FAIL\n"
 			exit 1
 		}
-		-re {rcu_sched detected stalls} {
+		-re {rcu.*detected stalls} {
 			info " Kernel error: '$expect_out(0,string)'\n"
 			exit 1
 		}


### PR DESCRIPTION
Update the regular expression that catches RCU errors from the kernel in order to report an error upon:

  [   79.434969] rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:

Without this fix, the test framework would either report a timeout (if the command causing the RCU message has hung), or report nothing (if the RCU message is triggered by a different thread of execution).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
