### PR TITLE
imx: update fdt_addr and initrd_addr

### DIFF
--- a/imx/u-boot_boot_script
+++ b/imx/u-boot_boot_script
@@ -1,3 +1,5 @@
+env set fdt_addr 0x45000000;
+env set initrd_addr 0x45800000;
 run loadfdt;
 fdt addr ${fdt_addr};
 fdt get value optee_compatible /firmware/optee compatible;


### PR DESCRIPTION
The kernel has grown and overwrites fdt_addr when loaded. Fix this by updating the fdr_addr and initrd_addr variables the addresses further up in memory.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
