### PR TITLE
rpi3: update uboot.env.txt defaults

### DIFF
--- a/rpi3/firmware/uboot.env.txt
+++ b/rpi3/firmware/uboot.env.txt
@@ -19,10 +19,11 @@ fdt_addr_r=0x01000000
 kernel_addr_r=0x02000000
 
 # NFS/TFTP boot configuraton
-gatewayip=192.168.1.1
+gatewayip=192.168.0.1
 netmask=255.255.255.0
-nfsserverip=192.168.1.100
+nfsserverip=192.168.0.100
 nfspath=/srv/nfs/rpi
+nfsversion=4
 
 # bootcmd & bootargs configuration
 preboot=usb start
@@ -31,6 +32,6 @@ load_kernel=fatload mmc 0:1 ${kernel_addr_r} kernel8.img
 mmcboot=run load_kernel; run set_bootargs_tty set_bootargs_mmc set_common_args; run boot_it
 nfsboot=run load_kernel; run set_bootargs_tty set_bootargs_nfs set_common_args; run boot_it
 set_bootargs_tty=setenv bootargs console=${ttyconsole} console=${sttyconsole},${baudrate}
-set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${nfsserverip}:${nfspath},udp,vers=3 ip=dhcp
+set_bootargs_nfs=setenv bootargs ${bootargs} root=/dev/nfs rw rootfstype=nfs nfsroot=${nfsserverip}:${nfspath},tcp,vers=${nfsversion} ip=dhcp
 set_bootargs_mmc=setenv bootargs ${bootargs} root=/dev/mmcblk0p2 rw rootfs=ext4
 set_common_args=setenv bootargs ${bootargs} smsc95xx.macaddr=${ethaddr} 'ignore_loglevel dma.dmachans=0x7f35 rootwait 8250.nr_uarts=1 elevator=deadline fsck.repair=yes bcm2708_fb.fbwidth=1920 bcm2708_fb.fbheight=1080 vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 dwc_otg.fiq_enable=0 dwc_otg.fiq_fsm_enable=0 dwc_otg.nak_holdoff=0'


### PR DESCRIPTION
* Change kernel commandline to use TCP instead of UDP. Recent rpcbind defaults use TCP only (check with: 'rpcinfo -p <myip> | grep nfs'). Using TCP should give a more robust connections overall.
* Add "nfsversion" variable to ease experimentation with different NFS versions when using various systems.
* Update "nfsserverip" IP address to match examples in RPi3 documentation.

This relates to https://github.com/OP-TEE/optee_docs/pull/260.