### PR TITLE
qemu_v8: fix "SCMI_DTB" with QEMU v9.2.0

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -577,6 +577,10 @@ QEMU_BASE_ARGS += $(QEMU_XEN)
 QEMU_BASE_ARGS += $(QEMU_EXTRA_ARGS)
 QEMU_BASE_ARGS += -machine virt,acpi=off,secure=on,mte=$(QEMU_MTE),gic-version=$(QEMU_GIC_VERSION),virtualization=$(QEMU_VIRT)
 
+# The aarch64-softmmu part of the path to qemu-system-aarch64 was removed
+# somewhere between 8.1.2 and 9.1.2
+QEMU_BIN = $(or $(wildcard $(QEMU_BUILD)/qemu-system-aarch64),$(wildcard $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64),qemu-system-aarch64-not-found)
+
 ifeq ($(WITH_SCMI),y)
 QEMU_SCMI_ARGS 	= -dtb $(SCMI_DTB)
 
@@ -586,7 +590,7 @@ $(SCMI_DTBO): $(SCMI_DTSO)
 
 $(SCMI_DTB): $(SCMI_DTBO) $(QEMU_BUILD)/.stamp_qemu linux arm-tf buildroot
 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
-	cd $(BINARIES_PATH) && $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64 \
+	cd $(BINARIES_PATH) && $(QEMU_BIN) \
 		$(QEMU_BASE_ARGS) -machine dumpdtb=qemu_v8.dtb
 	cd $(BINARIES_PATH) && fdtoverlay -i qemu_v8.dtb -o $(SCMI_DTB) $(SCMI_DTBO)
 endif
@@ -594,10 +598,6 @@ endif
 QEMU_RUN_ARGS = $(QEMU_BASE_ARGS) $(QEMU_SCMI_ARGS)
 QEMU_RUN_ARGS += $(QEMU_RUN_ARGS_COMMON)
 QEMU_RUN_ARGS += -s -S -serial tcp:127.0.0.1:$(QEMU_NW_PORT) -serial tcp:127.0.0.1:$(QEMU_SW_PORT) 
-
-# The aarch64-softmmu part of the path to qemu-system-aarch64 was removed
-# somewhere between 8.1.2 and 9.1.2
-QEMU_BIN = $(or $(wildcard $(QEMU_BUILD)/qemu-system-aarch64),$(wildcard $(QEMU_BUILD)/aarch64-softmmu/qemu-system-aarch64),qemu-system-aarch64-not-found)
 
 .PHONY: run-only
 run-only:


### PR DESCRIPTION
Commit 1977c37e46d4 ("qemu_v8: support new path to QEMU v9.2.0") allows QEMU v9.2.0 to be used for 'make run[-only]', but it does not take into account 'make $(SCMI_DTB)'.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
