### PR TITLE
qemu_v8.mk: use DEBUG default value from common.mk

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -38,8 +38,6 @@ endif
 # Enable fTPM
 MEASURED_BOOT_FTPM ?= y
 
-DEBUG ?= 1
-
 # Option to build with GICV3 enabled
 GICV3 ?= y
 


### PR DESCRIPTION
Let common.mk set the default DEBUG value instead of setting a default value before including common.mk. The restores the default value 0 for DEBUG used before commit 85cc2db7efeb ("qemu_v8: add Trusted Services support"). This should also fix the CI build for Hafnium.

Fixes: 85cc2db7efeb ("qemu_v8: add Trusted Services support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
