### PR TITLE
nanopc-t6: add fit_wrapper.sh with TEE_LOAD_ADDR=0x30000000

### DIFF
--- a/kconfigs/u-boot_nanopc-t6.conf
+++ b/kconfigs/u-boot_nanopc-t6.conf
@@ -19,3 +19,4 @@ CONFIG_BOOTARGS="console=ttyFIQ0,1500000 root=PARTUUID=17d61bff-8fdc-4089-b675-9
 CONFIG_DEFAULT_FDT_FILE="/boot/rk3588-nanopi6-rev01.dtb"
 ## Note: BOOTCOMMAND defined in u-boot/include/configs/nanopi6.h
 CONFIG_BOOTDELAY=0
+CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-rockchip/fit_wrapper.sh"

--- a/nanopc-t6.mk
+++ b/nanopc-t6.mk
@@ -22,8 +22,10 @@ BOOT_IMG		?= $(ROOT)/out/nanopc-t6.img
 TPL_BIN			?= $(BINARIES_PATH)/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.18.bin
 BOOT_CMD		?= $(ROOT)/build/nanopc-t6/nanopi6.h
 BOARD_DTSO		?= $(ROOT)/build/nanopc-t6/rk3588-nanopi6-optee.dtso
+FIT_WRAPPER		?= $(ROOT)/build/nanopc-t6/fit_wrapper.sh
 LINUX_DTSI		?= $(LINUX_PATH)/arch/arm64/boot/dts/rockchip/rk3588-nanopi6-common.dtsi
 UBOOT_HEADER		?= $(UBOOT_PATH)/include/configs/nanopi6.h
+UBOOT_FIT		?= $(UBOOT_PATH)/arch/arm/mach-rockchip/fit_wrapper.sh
 
 LINUX_MODULES ?= n
 
@@ -132,12 +134,15 @@ u-boot-proper: $(TPL_BIN) $(UBOOT_PATH)/.config u-boot-config
 u-boot-apply-bootcmd:
 	cp $(BOOT_CMD) $(UBOOT_HEADER)
 
+$(UBOOT_FIT): $(FIT_WRAPPER)
+	cp $< $@
+
 .PHONY: u-boot-loader
 u-boot-loader: u-boot-proper
 	$(UBOOT_PATH)/tools/mkimage -n rk3588 -T rksd -d $(UBOOT_PATH)/tpl/u-boot-tpl.bin:$(UBOOT_PATH)/spl/u-boot-spl.bin $(UBOOT_PATH)/idbloader.img
 
 .PHONY: u-boot
-u-boot: u-boot-apply-bootcmd $(TPL_BIN) $(UBOOT_PATH)/.config u-boot-loader
+u-boot: u-boot-apply-bootcmd $(UBOOT_FIT) $(TPL_BIN) $(UBOOT_PATH)/.config u-boot-loader
 	$(UBOOT_EXPORTS) $(MAKE) -C $(UBOOT_PATH) $(UBOOT_FLAGS) u-boot.itb
 
 .PHONY: u-boot-clean

--- a/nanopc-t6/fit_wrapper.sh
+++ b/nanopc-t6/fit_wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# file: fit_wrapper.sh
+export TEE_LOAD_ADDR=0x30000000
+exec arch/arm/mach-rockchip/make_fit_atf.sh

--- a/nanopc-t6/rk3588-nanopi6-optee.dtso
+++ b/nanopc-t6/rk3588-nanopi6-optee.dtso
@@ -17,8 +17,8 @@
                 #size-cells = <2>;
                 ranges;
 
-                optee@8400000 {
-                    reg = <0x0 0x8400000 0x0 0x2000000>;
+                optee@30000000 {
+                    reg = <0x0 0x30000000 0x0 0x2000000>;
                     no-map;
                 };
             };


### PR DESCRIPTION

Switch the NanoPC-T6 TEE load address from `0x08400000` to `0x30000000` by adding a local `fit_args.sh` and updating the device tree overlay. This aligns with [optee_os#7254](https://github.com/OP-TEE/optee_os/pull/7254), so merge this after that PR.