### PR TITLE
optee_rust_examples_ext: use 'rust install toolchain'

### DIFF
--- a/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
+++ b/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk
@@ -11,15 +11,12 @@ EXAMPLE = $(wildcard examples/*)
 
 define OPTEE_RUST_EXAMPLES_EXT_CONFIGURE_CMDS
 	# Ensure the toolchain, components, and targets we've specified in
-	# rust-toolchain.toml are ready to go. Since that file sets rustup's
-	# default toolchain for the entire directory, all we need to do is run
-	# any rustup-wrapped command to trigger installation. We've arbitrarily
-	# chosen "cargo --version" since it has no other effect.
+	# rust-toolchain.toml are ready to go.
 	@echo Configuring OP-TEE rust examples && \
 	export RUSTUP_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.rustup && \
 	export CARGO_HOME=$(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo && \
 	source $(OPTEE_RUST_EXAMPLES_EXT_TC_PATH)/.cargo/env && \
-	cd $(@D) && cargo --version >/dev/null
+	cd $(@D) && rustup toolchain install
 endef
 
 define OPTEE_RUST_EXAMPLES_EXT_BUILD_CMDS


### PR DESCRIPTION
Invoke 'rust install toolchain' instead of relying on a side effect of 'cargo --version'. It looks like the side effect doesn't exist anymore. From optee_os CI:

 2025-03-04T10:15:19.2947623Z Configuring OP-TEE rust examples
 2025-03-04T10:15:19.3387454Z error: toolchain 'nightly-2023-12-18-x86_64-unknown-linux-gnu' is not installed
 2025-03-04T10:15:19.3389280Z help: run `rustup toolchain install nightly-2023-12-18-x86_64-unknown-linux-gnu` to install it
 2025-03-04T10:15:19.3403890Z make[2]: *** [package/pkg-generic.mk:273: /__w/optee_test/optee_repo_qemu_v8/out-br/build/optee_rust_examples_ext-1.0/.stamp_configured] Error 1
 2025-03-04T10:15:19.3405144Z make[2]: *** Waiting for unfinished jobs....

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
