### PR TITLE
cmake: raise minimum required to 3.5

### DIFF
--- a/br-ext/package/ftpm_optee_ext/CMakeLists.txt
+++ b/br-ext/package/ftpm_optee_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 project(ftpm_optee_ext)
 
 # This is a dummy Makefile. When this package is invoked, the fTPM service

--- a/br-ext/package/linux_ftpm_mod_ext/CMakeLists.txt
+++ b/br-ext/package/linux_ftpm_mod_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 project(linux_ftpm_mod_ext)
 
 # This is a dummy Makefile. When this package is invoked, the TPM Kernel

--- a/br-ext/package/optee_os_ext/CMakeLists.txt
+++ b/br-ext/package/optee_os_ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 project(optee_os_ext)
 
 # This is a dummy Makefile. When this package is invoked, OP-TEE has been built


### PR DESCRIPTION
CMake 4.0 was released [1] which dropped compatibility with versions older than 3.5 and causes cmake_minimum_required(3.4) to fail. Bump the minimum required version to 3.5, which was released 9 years ago.

[1] https://www.kitware.com/cmake-4-0-0-available-for-download/

With v4.0.0 the following build error is observed:

  |  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  |  Compatibility with CMake < 3.5 has been removed from CMake.
  |
  |  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  |  to tell CMake that the project requires at least <min> but has been updated
  |  to work with policies introduced by <max> or earlier.
  |
  |  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

The issue was observed when building buildroot with OPTEE configs in a docker with cmake v4.0.0