### PR TITLE
qemu_v7: add CC=... to TF_A_EXPORTS

### DIFF
--- a/qemu.mk
+++ b/qemu.mk
@@ -40,7 +40,9 @@ include toolchain.mk
 # ARM Trusted Firmware
 ################################################################################
 TF_A_EXPORTS ?= \
-	CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)"
+	CROSS_COMPILE="$(CCACHE)$(AARCH32_CROSS_COMPILE)" \
+	CC="$(CCACHE)$(AARCH32_CROSS_COMPILE)gcc" \
+	LD="$(CCACHE)$(AARCH32_CROSS_COMPILE)ld"
 
 TF_A_DEBUG ?= $(DEBUG)
 ifeq ($(TF_A_DEBUG),0)


### PR DESCRIPTION
Add CC="$(CCACHE)$(AARCH32_CROSS_COMPILE)gcc" to TF_A_EXPORTS for compiling TF-A v2.12.

Older and newer versions of TF-A can be compiled without issue if both CROSS_COMPILE and CC are set in TF_A_EXPORTS.

This dependency was introduced by the TF-A commit 3789c3c00090 ("build: determine toolchain tools dynamically")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
