### PR TITLE
qemu: Fix uninitialized variables

### DIFF
--- a/qemu-check.exp
+++ b/qemu-check.exp
@@ -56,6 +56,8 @@ proc info arg {
 
 proc check_test_result arg {
 	set casenum "none"
+	set star 0
+	set ncases 0
 	expect {
 		# Exit with error status as soon as a test fails
 		-re {  ([^ ]+) FAIL} {


### PR DESCRIPTION
Fix uninitialized variables in procedure 'check_test_result'.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
