### PR TITLE
qemu_v8: OP-TEE SP fix uart interrupt config

### DIFF
--- a/qemu_v8/optee_sp_manifest.dts
+++ b/qemu_v8/optee_sp_manifest.dts
@@ -48,8 +48,8 @@
 			base-address = <0x00000000 0x09040000>;
 			pages-count = <1>;
 			attributes = <0x3>; /* read-write */
-			/* SPI, level-triggered, secure, priority=1 */
-			interrupts = <0x28 0xb01>;
+			/* SPI, edge-triggered, secure, priority=1 */
+			interrupts = <0x28 0x901>;
 		};
 	};
 };


### PR DESCRIPTION
The UART interrupt was configured as level-triggered prior to this patch, but it should be edge-triggered. So fix the level configuration.

Suggested-by: Olivier Deprez <olivier.deprez@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
