### PR TITLE
versal2: reorganize Buildroot related configs

### DIFF
--- a/versal2.mk
+++ b/versal2.mk
@@ -8,6 +8,8 @@ override COMPILE_NS_KERNEL	:= 64
 override COMPILE_S_USER		:= 64
 override COMPILE_S_KERNEL	:= 64
 
+PLATFORM = AMD Versal Gen 2
+
 # Network support related packages:
 BR2_PACKAGE_DHCPCD	?= y
 BR2_PACKAGE_ETHTOOL	?= y
@@ -22,7 +24,15 @@ BR2_PACKAGE_OPENSSH_KEY_UTILS	?= y
 BR2_PACKAGE_LIBOPENSSL_BIN	?= y
 BR2_PACKAGE_LIBP11	?= y
 
-PLATFORM = AMD Versal Gen 2
+# Busybox
+BR2_PACKAGE_BUSYBOX_WATCHDOG    ?= y
+
+# Target specific
+BR2_TARGET_GENERIC_ISSUE	?= "OP-TEE embedded distrib for $(PLATFORM)"
+BR2_TARGET_GENERIC_GETTY_PORT   ?= "console"
+BR2_TARGET_ROOTFS_EXT2		?= y
+
+# OP-TEE
 OPTEE_OS_PLATFORM = versal2
 OPTEE_OS_COMMON_EXTRA_FLAGS ?= CFG_PKCS11_TA=y CFG_USER_TA_TARGET_pkcs11=ta_arm64 O=out/arm
 
@@ -160,10 +170,6 @@ linux-cleaner: linux-cleaner-common
 ################################################################################
 # Buildroot
 ################################################################################
-
-BR2_TARGET_GENERIC_ISSUE	?= "OP-TEE embedded distrib for $(PLATFORM)"
-BR2_TARGET_ROOTFS_EXT2	?= y
-BR2_PACKAGE_BUSYBOX_WATCHDOG	?= y
 
 buildroot_mkimg: buildroot
 	mkdir -p $(BINARIES_PATH)


### PR DESCRIPTION
Reorganize all Buildroot configuration settings specific to the platform before including common.mk, ensuring that the platform-specific default configurations are correctly applied and take effect as intended.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
