### PR TITLE
qemu_v8: u-boot: Relocate RAM disk to avoid kernel overlap

### DIFF
--- a/kconfigs/u-boot_qemu_v8.conf
+++ b/kconfigs/u-boot_qemu_v8.conf
@@ -1,3 +1,3 @@
 CONFIG_SYS_TEXT_BASE=0x60000000
-CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x42200000 && setenv ramdisk_addr_r 0x45000000 && load hostfs - ${kernel_addr_r} uImage && load hostfs - ${ramdisk_addr_r} rootfs.cpio.uboot &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
+CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x42200000 && setenv ramdisk_addr_r 0x46000000 && load hostfs - ${kernel_addr_r} uImage && load hostfs - ${ramdisk_addr_r} rootfs.cpio.uboot &&  setenv bootargs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 root=/dev/ram && bootm ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}"
 CONFIG_SEMIHOSTING=y


### PR DESCRIPTION
A kernel built from v16-rc1 sources now overlaps with the default RAM disk load address in U-Boot 2025.07-rc1, causing a boot failure with a "Bad Data CRC" error.

Kernel end address:       0x45046A00
Previous RAM disk address:  0x45000000

This patch moves the RAM disk load address (`${ramdisk_addr_r}`) to `0x46000000`, resolving the memory conflict and providing a margin for future kernel growth.

The resulting boot error that is fixed was:
   Image Name:   Linux kernel
   Created:      2025-06-10  14:55:53 UTC
   Image Type:   AArch64 Linux Kernel Image (uncompressed)
   Data Size:    48523776 Bytes = 46.3 MiB
   Load Address: 42200000
   Entry Point:  42200000
   Verifying Checksum ... Bad Data CRC
ERROR -22: can't get kernel image!

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
