### PR TITLE
imx: Fix TF-A v2.12 ccache issue

### DIFF
--- a/imx.mk
+++ b/imx.mk
@@ -62,7 +62,10 @@ include toolchain.mk
 ################################################################################
 # ARM Trusted Firmware
 ################################################################################
-TF_A_EXPORTS = CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)"
+TF_A_EXPORTS ?= \
+	CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" \
+	CC="$(CCACHE)$(AARCH64_CROSS_COMPILE)gcc" \
+	LD="$(CCACHE)$(AARCH64_CROSS_COMPILE)ld"
 
 #	BL32=$(OPTEE_OS_HEADER_V2_BIN) \
 #	BL32_EXTRA1=$(OPTEE_OS_PAGER_V2_BIN) \


### PR DESCRIPTION
TF-A build system defines CROSS_COMPILE to hold the GCC target prefix. v2.12 implements more strict value checking which needs changes here.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
