### PR TITLE
Fvp updates

### DIFF
--- a/fvp.mk
+++ b/fvp.mk
@@ -402,7 +402,9 @@ else ifneq ($(STY),)
 	FVP_SERIAL_CMD_ARGS += -C bp.terminal_3.terminal_command="$(FVP_TELNET_CMD)"
 endif
 ifeq ($(TS_LOGGING_SP),y)
+ifneq ($(TS_LOGGING_SP_LOG),)
 	FVP_ARGS += -C bp.pl011_uart2.out_file=$(TS_LOGGING_SP_LOG)
+endif
 endif
 ifeq ($(FVP_VIRTFS_ENABLE),y)
 	FVP_ARGS += -C bp.virtiop9device.root_path=$(FVP_VIRTFS_HOST_DIR)

--- a/fvp.mk
+++ b/fvp.mk
@@ -383,6 +383,23 @@ ifeq ($(FVP_NO_VISUALISATION),y)
 		    -C bp.terminal_2.start_telnet=0 \
 		    -C bp.terminal_3.mode=raw \
 		    -C bp.terminal_3.start_telnet=0
+else ifneq ($(FVP_TELNET_CMD),)
+	FVP_SERIAL_CMD_ARGS := -C bp.terminal_0.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_1.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_2.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_3.terminal_command="$(FVP_TELNET_CMD)"
+else ifneq ($(TMUX),)
+	FVP_TELNET_CMD := tmux new-window -n \"%title\" \"telnet localhost %port\"
+	FVP_SERIAL_CMD_ARGS := -C bp.terminal_0.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_1.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_2.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_3.terminal_command="$(FVP_TELNET_CMD)"
+else ifneq ($(STY),)
+	FVP_TELNET_CMD := screen -S $$STY -X screen -t \"%title\" -L telnet localhost %port
+	FVP_SERIAL_CMD_ARGS := -C bp.terminal_0.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_1.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_2.terminal_command="$(FVP_TELNET_CMD)"
+	FVP_SERIAL_CMD_ARGS += -C bp.terminal_3.terminal_command="$(FVP_TELNET_CMD)"
 endif
 ifeq ($(TS_LOGGING_SP),y)
 	FVP_ARGS += -C bp.pl011_uart2.out_file=$(TS_LOGGING_SP_LOG)
@@ -392,4 +409,4 @@ ifeq ($(FVP_VIRTFS_ENABLE),y)
 endif
 
 run-only:
-	$(FVP_PATH)/$(FVP_BIN) $(FVP_ARGS) $(FVP_EXTRA_ARGS)
+	$(FVP_PATH)/$(FVP_BIN) $(FVP_ARGS) $(FVP_EXTRA_ARGS) $(FVP_SERIAL_CMD_ARGS)


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
This MR carries two changes:
- Allow specifying a telnet terminal command to the FVP when started. The change adds automatic discovery for tmux os screen session and will start each telnet terminal (emulated serial line) of the FVP in a dedicated window. (This change was inspired by the ``--terminals`` argument of the ``runfvp`` [command of meta-arm](https://github.com/jonmason/meta-arm/blob/master/documentation/runfvp.md).)
- Make redirecting the TS Logging SP output to a file optional.


