### PR TITLE
nanopc-t6: update TPL_BIN to v1.21 from manifest

### DIFF
--- a/nanopc-t6.mk
+++ b/nanopc-t6.mk
@@ -19,7 +19,7 @@ UBOOT_PATH		?= $(ROOT)/u-boot
 UBOOT_BIN		?= $(UBOOT_PATH)/u-boot.bin
 ROOT_IMG		?= $(ROOT)/out-br/images/rootfs.ext2
 BOOT_IMG		?= $(ROOT)/out/nanopc-t6.img
-TPL_BIN			?= $(BINARIES_PATH)/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.19.bin
+TPL_BIN			?= $(BINARIES_PATH)/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.21.bin
 BOOT_CMD		?= $(ROOT)/build/nanopc-t6/nanopi6.h
 BOARD_DTSO		?= $(ROOT)/build/nanopc-t6/rk3588-nanopi6-optee.dtso
 FIT_WRAPPER		?= $(ROOT)/build/nanopc-t6/fit_wrapper.sh
@@ -107,7 +107,6 @@ UBOOT_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE_NS_KERNEL) \
 
 $(TPL_BIN):
 	mkdir -p $(BINARIES_PATH)
-	wget -O $(TPL_BIN) https://github.com/rockchip-linux/rkbin/raw/master/bin/rk35/$(notdir $(TPL_BIN))
 
 UBOOT_EXPORTS ?= BL31=$(TF_A_OUT)/bl31/bl31.elf \
                  TEE=$(OPTEE_OS_BIN) \


### PR DESCRIPTION
Update TPL_BIN to rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.21.bin. Remove wget-based population of TPL_BIN now that rkbin provides it through the manifest (https://github.com/OP-TEE/manifest/pull/349)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
