### PR TITLE
qemu_v8: retry Hafnium submodule update and use HTTP/1.1

### DIFF
--- a/qemu_v8.mk
+++ b/qemu_v8.mk
@@ -529,9 +529,12 @@ optee-os-clean: optee-os-clean-common
 ################################################################################
 
 HAFNIUM_EXPORTS = PATH=$(TOOLCHAIN_ROOT)/clang-$(CLANG_BUILD_VER)/bin:$(PATH)
+# The large prebuilts submodule has hit HTTP/2 stream resets in CI.
+HAFNIUM_SUBMODULE_UPDATE = git -c http.version=HTTP/1.1 \
+	-C $(HAFNIUM_PATH) submodule update --init
 
 .hafnium_checkout:
-	git -C $(HAFNIUM_PATH) submodule update --init
+	$(HAFNIUM_SUBMODULE_UPDATE) || $(HAFNIUM_SUBMODULE_UPDATE)
 	touch $@
 
 hafnium: $(HAFNIUM_BIN)


### PR DESCRIPTION
The Hafnium prebuilts submodule fetch can fail in CI with an HTTP/2 stream reset while fetching the large pack.

Force HTTP/1.1 for this update and retry once so transient fetch failures do not fail the QEMU v8 job.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
